### PR TITLE
fixing decoding issue

### DIFF
--- a/rebiber/bib2json.py
+++ b/rebiber/bib2json.py
@@ -17,7 +17,7 @@ def normalize_title(title_str):
 
 def load_bib_file(bibpath):
     all_bib_entries = []
-    with open(bibpath) as f:
+    with open(bibpath, encoding='utf8') as f:
         bib_entry_buffer = []
         lines = f.readlines() + ["\n"]
         for ind, line in enumerate(lines):

--- a/rebiber/normalize.py
+++ b/rebiber/normalize.py
@@ -56,9 +56,10 @@ def post_processing(output_bib_entries, removed_value_names, abbr_dict):
             if remove_name in output_entry:
                 del output_entry[remove_name]
         for short, pattern in abbr_dict.items():
-            if "booktitle" in output_entry:
-                if re.match(pattern, output_entry["booktitle"]):
-                    output_entry["booktitle"] = short
+            for place in ["booktitle", "journal"]:
+                if place in output_entry:
+                    if re.match(pattern, output_entry[place]):
+                        output_entry[place] = short
                 
     return bibtexparser.dumps(parsed_entries)
 

--- a/rebiber/normalize.py
+++ b/rebiber/normalize.py
@@ -56,10 +56,9 @@ def post_processing(output_bib_entries, removed_value_names, abbr_dict):
             if remove_name in output_entry:
                 del output_entry[remove_name]
         for short, pattern in abbr_dict.items():
-            for place in ["booktitle", "journal"]:
-                if place in output_entry:
-                    if re.match(pattern, output_entry[place]):
-                        output_entry[place] = short
+            if "booktitle" in output_entry:
+                if re.match(pattern, output_entry["booktitle"]):
+                    output_entry["booktitle"] = short
                 
     return bibtexparser.dumps(parsed_entries)
 
@@ -107,7 +106,7 @@ def normalize_bib(bib_db, all_bib_entries, output_bib_path, deduplicate=True, re
     print("Num of converted items:", num_converted)
     # post-formatting 
     output_string = post_processing(output_bib_entries, removed_value_names, abbr_dict)
-    with open(output_bib_path, "w") as output_file:
+    with open(output_bib_path, "w", encoding='utf8') as output_file:
         output_file.write(output_string)
     print("Written to:", output_bib_path)
 


### PR DESCRIPTION
I got these bugs today when I used your script:
```
Traceback (most recent call last):
  File "c:\users\tiany\appdata\local\programs\python\python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\users\tiany\appdata\local\programs\python\python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\tiany\AppData\Local\Programs\Python\Python37\Scripts\rebiber.exe\__main__.py", line 7, in <module>
  File "c:\users\tiany\appdata\local\programs\python\python37\lib\site-packages\rebiber\normalize.py", line 165, in main
    all_bib_entries = load_bib_file(args.input_bib)
  File "c:\users\tiany\appdata\local\programs\python\python37\lib\site-packages\rebiber\bib2json.py", line 22, in load_bib_file
    lines = f.readlines() + ["\n"]
UnicodeDecodeError: 'gbk' codec can't decode byte 0x9d in position 6526: illegal multibyte sequence

Traceback (most recent call last):
  File "c:\users\tiany\appdata\local\programs\python\python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\users\tiany\appdata\local\programs\python\python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\tiany\AppData\Local\Programs\Python\Python37\Scripts\rebiber.exe\__main__.py", line 7, in <module>
  File "c:\users\tiany\appdata\local\programs\python\python37\lib\site-packages\rebiber\normalize.py", line 172, in main
    normalize_bib(bib_db, all_bib_entries, output_path, args.deduplicate, removed_value_names, abbr_dict)
  File "c:\users\tiany\appdata\local\programs\python\python37\lib\site-packages\rebiber\normalize.py", line 110, in normalize_bib
    output_file.write(output_string)
UnicodeEncodeError: 'gbk' codec can't encode character '\u0107' in position 4023: illegal multibyte sequence
```
To fix them, I added `encoding='utf8' ` in the IO process of both `bib2json.py` and `normalize.py`. It works well for me now.