### PR TITLE
fix reference filter issue

### DIFF
--- a/rebiber/bib2json.py
+++ b/rebiber/bib2json.py
@@ -28,7 +28,10 @@ def load_bib_file(bibpath):
             if line.strip() == "}" or (line.strip().endswith("}") and "{" not in line and ind+1<len(lines) and lines[ind+1]=="\n"):
                 all_bib_entries.append(bib_entry_buffer)
                 bib_entry_buffer = []
-            
+            elif line.strip().endswith("}}"):
+                bib_entry_buffer.append('}\n')
+                all_bib_entries.append(bib_entry_buffer)
+                bib_entry_buffer = []  
     return all_bib_entries
 
 def build_json(all_bib_entries):


### PR DESCRIPTION
Fix #21 

Add one more condition to the load_bib_file() function in rebiber/bib2json.py file, which will handle the case when the final closed curly brace `}` is in the same line as the last bib entry. 