### PR TITLE
Remove unnecessary debug message added in PR #23

### DIFF
--- a/rebiber/normalize.py
+++ b/rebiber/normalize.py
@@ -77,9 +77,7 @@ def normalize_bib(bib_db, all_bib_entries, output_bib_path, deduplicate=True, re
         original_title = ""
         original_bibkey = ""
         bib_entry_str = " ".join([line for line in bib_entry if not is_contain_var(line)])
-        print("bib_entry_str = ", bib_entry_str)
         bib_entry_parsed = bibtexparser.loads(bib_entry_str, bibparser)
-        print(bib_entry_parsed.entries[0])
         if len(bib_entry_parsed.entries)==0 or "title" not in bib_entry_parsed.entries[0]:
             continue
         original_title = bib_entry_parsed.entries[0]["title"]


### PR DESCRIPTION
In #23 I added another commit (by mistake-- sorry, don't have much experience with PRs) that prints some debug messages and fixes a small bug. This PR removes the debug messages for cleaner output.

The bug that I fixed is this: if the input BibTeX file is like

`@article{abbasi-yadkori11_onlin_least_squar_estim_with,
  author       = {Abbasi-Yadkori, Yasin and Pal, David and Szepesvari, Csaba},
  url          = {http://arxiv.org/abs/1102.2670v1},
  date         = 2011,
  eprint       = {1102.2670},
  eprintclass  = {cs.AI},
  eprinttype   = {arXiv},
  journaltitle = {arXiv preprint arXiv:1102.2670},
  title        = {Online Least Squares Estimation With Self-Normalized Processes: an Application To Bandit Problems},
}`

rebiber would remove the _date_ field because its value (2011 above) is not enclosed between pointy braces. However, integer values do not have to be enclosed in pointy braces [per the BibTeX format](https://www.bibtex.com/f/year-field/). The 2nd commit in #23 fixed this bug. Sorry for any inconvenience.