### PR TITLE
Issues output entries order

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ You can find a pair of example input and output files in `rebiber/example_input.
 | `-d` | or `--deduplicate`. A bool argument that is `"True"` by __default__, used for removing the duplicate bib entries sharing the same key. Used as `-d True`. |
 | `-l` | or `--bib_list`. The path to the list of the bib json files to be loaded. Check [rebiber/bib_list.txt](rebiber/bib_list.txt) for the default file. Usually you don't need to set this argument. |
 | `-a` | or `--abbr_tsv`. The list of conference abbreviation data. Check [rebiber/abbr.tsv](rebiber/abbr.tsv) for the default file. Usually you don't need to set this argument. |
-| `-u` | or `--update`. Update the local bib-related data with the lateset Github version.
-| `-v` | or `--version`. Print the version of current Rebiber.
+| `-u` | or `--update`. Update the local bib-related data with the lateset Github version. |
+| `-v` | or `--version`. Print the version of current Rebiber. |
+| `-st` | or `--sort`. A bool argument that is `"False"` by __default__. used for keeping the original order of the bib entries of the input file. By setting it to be `"True"`, the bib entries are ordered alphabetically in the output file. Used as `-st True`. |
 
 <!-- Or 
 ```bash


### PR DESCRIPTION
Modify the normalize.py file to include a new input argument, `--sort`, for sorting. Previously, the bib entries were sorted in alphabetic order in the output file. By adding this new input argument, users are able to decide if they want to keep the original bib entries order in the output file or not. The default of this argument is `False`, keeping the original order. By setting it to be `True`, the bib entries are sorted alphabetically in the output bib file. 

Fix one of the issues that mentioned in #22 . 