### PR TITLE
Issues entry format

### DIFF
--- a/rebiber/bib2json.py
+++ b/rebiber/bib2json.py
@@ -45,11 +45,11 @@ def load_bib_file(bibpath):
                 all_bib_entries.append(bib_entry_buffer)
                 bib_entry_buffer = []
             elif line.strip().endswith("}}"):
-                bib_entry_buffer[-1] = bib_entry_buffer[-1][:-1]
+                bib_entry_buffer[-1] = bib_entry_buffer[-1].strip()[:-1]
                 bib_entry_buffer.append('}\n')
                 all_bib_entries.append(bib_entry_buffer)
                 bib_entry_buffer = []
-    print(all_bib_entries)  
+    # print(all_bib_entries)  
     return all_bib_entries
 
 def build_json(all_bib_entries):

--- a/rebiber/bib2json.py
+++ b/rebiber/bib2json.py
@@ -20,18 +20,36 @@ def load_bib_file(bibpath):
     with open(bibpath, encoding='utf8') as f:
         bib_entry_buffer = []
         lines = f.readlines() + ["\n"]
+
+        temp = -1
         for ind, line in enumerate(lines):
             # line = line.strip()
             if "@string" in line:
                 continue
-            bib_entry_buffer.append(line)
+            if temp >= ind:
+                continue
+            buffer = ""
+            if lines[ind].strip().endswith("={"):
+                temp = ind
+                while temp < len(lines) and not lines[temp].strip().endswith("}"):
+                    buffer += lines[temp].strip()
+                    temp += 1
+
+                buffer += lines[temp]
+                bib_entry_buffer.append(buffer)
+                buffer = ""                 
+            else:
+                bib_entry_buffer.append(lines[ind])
+
             if line.strip() == "}" or (line.strip().endswith("}") and "{" not in line and ind+1<len(lines) and lines[ind+1]=="\n"):
                 all_bib_entries.append(bib_entry_buffer)
                 bib_entry_buffer = []
             elif line.strip().endswith("}}"):
+                bib_entry_buffer[-1] = bib_entry_buffer[-1][:-1]
                 bib_entry_buffer.append('}\n')
                 all_bib_entries.append(bib_entry_buffer)
-                bib_entry_buffer = []  
+                bib_entry_buffer = []
+    print(all_bib_entries)  
     return all_bib_entries
 
 def build_json(all_bib_entries):


### PR DESCRIPTION
Fix #29 
Fix #26 

Update function load_bib_file() in the bib2json.py file to handle nonstandard bib entry in the input file. More specifically, example bib entries like

```
@article{Ando2005,
	Acmid = {1194905},
	Author = {Ando, Rie Kubota and Zhang, Tong},
	Issn = {1532-4435},
	Pages = {1817--1853},
	Publisher = {JMLR.org},
	Title = {A Framework for Learning Predictive Structures from Multiple Tasks and Unlabeled Data},
	Volume = {6},
	Year = {2005}}
```
where there is a double-closed braces at the end, and

```
@article{loon,
  title={Autonomous navigation of stratospheric balloons using reinforcement learning.},
  author={Marc G. Bellemare and Salvatore Candido and P. S. Castro and J. Gong and Marlos C. Machado and Subhodeep Moitra and Sameera S. Ponda and Ziyu Wang},
  journal={Nature},
  year={2020},
  volume={588 7836},
  pages={
          77-82
        }
}
```
where the `page` entry has multiple lines, are handled in the updated function.