### PR TITLE
Issues comment

### DIFF
--- a/rebiber/bib2json.py
+++ b/rebiber/bib2json.py
@@ -26,6 +26,8 @@ def load_bib_file(bibpath):
             # line = line.strip()
             if "@string" in line:
                 continue
+            if line.strip().startswith("%") or line.strip().startswith("#") or line.strip().startswith("//"):
+                continue
             if temp >= ind:
                 continue
             buffer = ""
@@ -49,7 +51,7 @@ def load_bib_file(bibpath):
                 bib_entry_buffer.append('}\n')
                 all_bib_entries.append(bib_entry_buffer)
                 bib_entry_buffer = []
-    # print(all_bib_entries)  
+    # print(all_bib_entries)
     return all_bib_entries
 
 def build_json(all_bib_entries):

--- a/rebiber/bib2json.py
+++ b/rebiber/bib2json.py
@@ -27,6 +27,8 @@ def load_bib_file(bibpath):
             if "@string" in line:
                 continue
             if line.strip().startswith("%") or line.strip().startswith("#") or line.strip().startswith("//"):
+                all_bib_entries.append([line])
+                bib_entry_buffer = []
                 continue
             if temp >= ind:
                 continue
@@ -53,6 +55,7 @@ def load_bib_file(bibpath):
                 bib_entry_buffer = []
     # print(all_bib_entries)
     return all_bib_entries
+
 
 def build_json(all_bib_entries):
     all_bib_dict = {}


### PR DESCRIPTION
Fix #22 

Add an additional checking condition to function load_bib_file() in bib2json.py to handle comments. Any line that starts with `%`, `//`, or `#` in the input bib file will not be transformed into @comment{} in the output bib file.