### PR TITLE
change bib2json method, fix }} bug in Issue #52

### DIFF
--- a/rebiber/bib2json.py
+++ b/rebiber/bib2json.py
@@ -21,38 +21,25 @@ def load_bib_file(bibpath):
         bib_entry_buffer = []
         lines = f.readlines() + ["\n"]
 
-        temp = -1
-        for ind, line in enumerate(lines):
-            # line = line.strip()
+        brace_count = 0  # Keep track of opened and closed braces
+
+        for line in lines:
             if "@string" in line:
                 continue
             if line.strip().startswith("%") or line.strip().startswith("#") or line.strip().startswith("//"):
-                all_bib_entries.append([line])
                 bib_entry_buffer = []
                 continue
-            if temp >= ind:
-                continue
-            buffer = ""
-            if lines[ind].strip().endswith("={"):
-                temp = ind
-                while temp < len(lines) and not lines[temp].strip().endswith("}"):
-                    buffer += lines[temp].strip()
-                    temp += 1
+            
+            bib_entry_buffer.append(line)
+            brace_count += line.count("{") - line.count("}")
 
-                buffer += lines[temp]
-                bib_entry_buffer.append(buffer)
-                buffer = ""                 
-            else:
-                bib_entry_buffer.append(lines[ind])
+            # If brace_count is zero, then all opened braces have been closed
+            if brace_count == 0:
+                # Filter out the entries that only contain ['\n'] or ['']
+                if bib_entry_buffer != ['\n'] and bib_entry_buffer != ['']:
+                    all_bib_entries.append(bib_entry_buffer)
+                bib_entry_buffer = []
 
-            if line.strip() == "}" or (line.strip().endswith("}") and "{" not in line and ind+1<len(lines) and lines[ind+1]=="\n"):
-                all_bib_entries.append(bib_entry_buffer)
-                bib_entry_buffer = []
-            elif line.strip().endswith("}}"):
-                bib_entry_buffer[-1] = bib_entry_buffer[-1].strip()[:-1]
-                bib_entry_buffer.append('}\n')
-                all_bib_entries.append(bib_entry_buffer)
-                bib_entry_buffer = []
     # print(all_bib_entries)
     return all_bib_entries
 


### PR DESCRIPTION
I have simplified the bib to json function using tracking of opened and closed braces.  Have tested on my bib file consisting of 288 entries. It works fine.

Also, this fixed the bug I mentioned in the Issue #52 , which happened in line:
```elif line.strip().endswith("}}"):```
Since some journal may ends with }} such as {{PMLR}} in my example.

