### PR TITLE
Harden title matching: fail-closed authors, et al., digit keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ rebiber -i input.bib [more.bib ...] [-o out.bib|outdir]
 
 ### Matching behavior (v1.3.0)
 
-- **Author-overlap guard.** A title-only match is not enough when the candidate official record looks like a different paper. Rebiber will not replace a "Deep Learning" book or *Nature* article with an unrelated KDD talk that happens to share a short/generic title. Use `--no-check-authors` only if you want the old title-only behavior.
+- **Author-overlap guard.** A title-only match is not enough when the candidate official record looks like a different paper. Rebiber will not replace a "Deep Learning" book or *Nature* article with an unrelated KDD talk that happens to share a short/generic title. Use `--no-check-authors` only if you want the old title-only behavior. Empty or missing authors on either side is **not** treated as a match (fail-closed), so editor-only front-matter such as a "Preface" will not replace a paper by that title. Trailing `et al.` / `and others` is stripped before last-name compare.
+- **Digit-preserving title keys.** Lookup first tries a key that keeps digits (`16x16` ≠ `32x32`) and falls back to the letters-only key used by older dumps.
+- **Unclosed braces.** A leftover buffer at end-of-file is kept with a warning instead of being dropped.
 - **ArXiv official fields.** Unofficial arXiv preprints are rewritten with standard fields (`eprint`, `archivePrefix`, `primaryClass`) instead of a free-form `journal = {arXiv preprint ...}` string.
 - **Published papers stay published.** Rebiber will not rewrite an already-published entry just because the abstract (or another field) mentions arXiv.
 - **Unparsed entries are kept.** Entries that fail to parse are not silently dropped from the output.

--- a/rebiber/bib2json.py
+++ b/rebiber/bib2json.py
@@ -12,14 +12,18 @@ filepath = os.path.dirname(os.path.abspath(__file__)) + "/"
 _SKIP_ENTRY_PREFIXES = ("@string", "@comment", "@preamble")
 
 
-def normalize_title(title_str):
-    """Normalize a title to a lowercase letters-only key (DB-compatible).
+def normalize_title(title_str, keep_digits=False):
+    """Normalize a title to a lowercase key.
 
-    Combining marks are dropped, then everything except ASCII letters is
-    stripped. Existing letter-only keys stay the same.
+    Combining marks are dropped, then non-letter characters are stripped.
+    By default only ASCII letters are kept (compatible with existing dumps).
+    Pass ``keep_digits=True`` to also keep ASCII digits (new dumps).
     """
     title_str = "".join(ch for ch in title_str if not unicodedata.combining(ch))
-    title_str = re.sub(r"[^a-zA-Z]", r"", title_str)
+    if keep_digits:
+        title_str = re.sub(r"[^a-zA-Z0-9]", r"", title_str)
+    else:
+        title_str = re.sub(r"[^a-zA-Z]", r"", title_str)
     return title_str.lower().replace(" ", "").strip()
 
 
@@ -75,7 +79,13 @@ def load_bib_file(bibpath):
                     all_bib_entries.append(bib_entry_buffer)
                 bib_entry_buffer = []
 
-    # print(all_bib_entries)
+    if bib_entry_buffer and bib_entry_buffer not in (["\n"], [""]):
+        print(
+            "WARNING: unclosed braces at end of %s; keeping leftover buffer."
+            % bibpath
+        )
+        all_bib_entries.append(bib_entry_buffer)
+
     return all_bib_entries
 
 
@@ -84,11 +94,17 @@ def build_json(all_bib_entries):
     num_exceptions = 0
     for bib_entry in tqdm(all_bib_entries[:]):
         bib_entry_str = " ".join(
-            [line for line in bib_entry if "month" not in line.lower()]
+            [
+                line
+                for line in bib_entry
+                if not re.search(r"month\s*=", line, flags=re.IGNORECASE)
+            ]
         ).lower()
         try:
             bib_entry_parsed = bibtexparser.loads(bib_entry_str)
-            bib_key = normalize_title(bib_entry_parsed.entries[0]["title"])
+            bib_key = normalize_title(
+                bib_entry_parsed.entries[0]["title"], keep_digits=True
+            )
             all_bib_dict[bib_key] = bib_entry
         except Exception as e:
             print(bib_entry)

--- a/rebiber/normalize.py
+++ b/rebiber/normalize.py
@@ -108,11 +108,11 @@ def post_processing(output_bib_entries, removed_value_names, abbr_dict, sort):
             bib_entry_str += line
         bib_entry_str += "\n"
     parsed_entries = bibtexparser.loads(bib_entry_str, bibparser)
-    if len(parsed_entries.entries) < len(output_bib_entries) - 5 or (
+    if len(parsed_entries.entries) != len(output_bib_entries) or (
         len(parsed_entries.entries) == 0 and len(output_bib_entries) > 0
     ):
         print(
-            "Warning: len(parsed_entries.entries) < len(output_bib_entries) -5 -->",
+            "Warning: len(parsed_entries.entries) != len(output_bib_entries) -->",
             len(parsed_entries.entries),
             len(output_bib_entries),
         )
@@ -170,6 +170,10 @@ def extract_last_names(author_field):
     for part in parts:
         part = strip_latex_markup(part)
         part = re.sub(r"\s+", " ", part).strip(" ,")
+        # Strip trailing "et al." / "and others" before taking the last token.
+        part = re.sub(r",?\s+et\s+al\.?\s*$", "", part, flags=re.IGNORECASE)
+        part = re.sub(r",?\s+and\s+others\s*$", "", part, flags=re.IGNORECASE)
+        part = part.strip(" ,")
         if not part:
             continue
         if part.lower() in ("others", "et al", "et al.", "etal"):
@@ -188,11 +192,11 @@ def extract_last_names(author_field):
 
 
 def authors_overlap(input_authors, db_authors):
-    """True if last names overlap, or if either side has no authors (unknown)."""
+    """True if last names overlap. Empty on either side is not a match."""
     input_names = extract_last_names(input_authors)
     db_names = extract_last_names(db_authors)
     if not input_names or not db_names:
-        return True
+        return False
     return bool(input_names & db_names)
 
 
@@ -449,7 +453,12 @@ def normalize_bib(
             stats["unchanged"] += 1
             continue
 
-        title = normalize_title(original_title) if original_title else ""
+        if original_title:
+            key_new = normalize_title(original_title, keep_digits=True)
+            key_old = normalize_title(original_title, keep_digits=False)
+            title = key_new if key_new in bib_db else key_old
+        else:
+            title = ""
         if title and title in bib_db:
             db_item = bib_db[title]
             db_authors = parse_db_authors(db_item)

--- a/tests/test_bib2json.py
+++ b/tests/test_bib2json.py
@@ -40,6 +40,21 @@ def test_normalize_title_strips_punctuation_lowercases_letters_only():
     # combining marks are dropped; ASCII letters remain
     assert normalize_title("naive") == "naive"
     assert normalize_title("naive\u0301") == "naive"
+    # default keep_digits=False drops digits
+    assert normalize_title("A 16x16 Network") == "axnetwork"
+    assert normalize_title("A 16x16 Network", keep_digits=False) == "axnetwork"
+
+
+def test_normalize_title_keep_digits_distinguishes_16x16_and_32x32():
+    t16 = "A 16x16 Network"
+    t32 = "A 32x32 Network"
+    assert normalize_title(t16, keep_digits=False) == "axnetwork"
+    assert normalize_title(t32, keep_digits=False) == "axnetwork"
+    assert normalize_title(t16, keep_digits=True) == "a16x16network"
+    assert normalize_title(t32, keep_digits=True) == "a32x32network"
+    assert normalize_title(t16, keep_digits=True) != normalize_title(
+        t32, keep_digits=True
+    )
 
 
 def test_load_bib_file_parses_two_entries_ignores_comments():
@@ -165,5 +180,75 @@ def test_build_json_keys_by_normalize_title():
         assert key_hello in db
         assert db[key_birds] == entries[0]
         assert db[key_hello] == entries[1]
+    finally:
+        os.unlink(path)
+
+
+def test_build_json_uses_keep_digits_keys():
+    path = _write_bib(
+        """
+@article{a,
+  title={A 16x16 Network},
+  year={2020}
+}
+@article{b,
+  title={A 32x32 Network},
+  year={2021}
+}
+"""
+    )
+    try:
+        entries = load_bib_file(path)
+        db = build_json(entries)
+        key16 = normalize_title("A 16x16 Network", keep_digits=True)
+        key32 = normalize_title("A 32x32 Network", keep_digits=True)
+        key_old = normalize_title("A 16x16 Network", keep_digits=False)
+        assert key16 == "a16x16network"
+        assert key32 == "a32x32network"
+        assert key_old == "axnetwork"
+        assert key16 in db
+        assert key32 in db
+        assert key_old not in db
+        assert db[key16] == entries[0]
+        assert db[key32] == entries[1]
+    finally:
+        os.unlink(path)
+
+
+def test_build_json_keeps_title_containing_month():
+    path = _write_bib(
+        """
+@article{m,
+  title={A Month of Sundays},
+  author={Alice},
+  month={jan},
+  year={2020}
+}
+"""
+    )
+    try:
+        entries = load_bib_file(path)
+        db = build_json(entries)
+        key = normalize_title("A Month of Sundays", keep_digits=True)
+        assert key == "amonthofsundays"
+        assert key in db
+        assert "A Month of Sundays" in "".join(db[key])
+    finally:
+        os.unlink(path)
+
+
+def test_load_bib_file_keeps_unclosed_entry():
+    path = _write_bib(
+        """@article{broken,
+  title={Unclosed Title},
+  author={Alice}
+"""
+    )
+    try:
+        entries = load_bib_file(path)
+        assert len(entries) == 1
+        joined = "".join(entries[0])
+        assert "Unclosed Title" in joined
+        assert "broken" in joined
     finally:
         os.unlink(path)

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -14,6 +14,7 @@ from rebiber.normalize import (
     extract_last_names,
     looks_published,
     normalize_bib,
+    post_processing,
     str2bool,
 )
 
@@ -187,9 +188,30 @@ class TestAuthorLastNames(unittest.TestCase):
         self.assertIn("dollar", names)
         self.assertIn("lin", names)
 
-    def test_overlap_unknown_when_missing(self):
-        self.assertTrue(authors_overlap("", "Ada Lovelace"))
-        self.assertTrue(authors_overlap("Ada Lovelace", None))
+    def test_et_al_stripped_before_last_token(self):
+        self.assertEqual(extract_last_names("De-An Huang et al."), {"huang"})
+        self.assertEqual(extract_last_names("De-An Huang, et al."), {"huang"})
+        self.assertEqual(extract_last_names("Huang, De-An et al."), {"huang"})
+        self.assertEqual(extract_last_names("De-An Huang and others"), {"huang"})
+        self.assertEqual(
+            extract_last_names("De-An Huang et al. and Yann LeCun"),
+            {"huang", "lecun"},
+        )
+        # Exact et al / others parts are still skipped.
+        self.assertEqual(
+            extract_last_names("Huang, De-An and et al."),
+            {"huang"},
+        )
+        self.assertEqual(
+            extract_last_names("Huang, De-An and others"),
+            {"huang"},
+        )
+        self.assertTrue(authors_overlap("De-An Huang et al.", "Huang, De-An"))
+
+    def test_overlap_empty_is_false(self):
+        self.assertFalse(authors_overlap("", "Ada Lovelace"))
+        self.assertFalse(authors_overlap("Ada Lovelace", None))
+        self.assertFalse(authors_overlap("", None))
 
 
 class TestIssue50AuthorCheck(unittest.TestCase):
@@ -370,6 +392,99 @@ class TestConstructBibDb(unittest.TestCase):
             db = construct_bib_db(list_path, start_dir=tmp)
             self.assertIn("hello", db)
             self.assertEqual(len(db), 1)
+
+
+PREFACE_EDITOR_ONLY = """@inproceedings{preface,
+  title={Preface},
+  editor={Someone Editor},
+  booktitle={Proceedings of Something},
+  year={2020}
+}
+"""
+
+JANE_DOE_PREFACE = """@article{janedoe,
+  title={Preface},
+  author={Jane Doe},
+  year={2020}
+}
+"""
+
+
+class TestFailClosedAuthorOverlap(unittest.TestCase):
+    def test_preface_editor_only_does_not_convert_jane_doe(self):
+        key = normalize_title("Preface")
+        db = {key: _db_entry_lines(PREFACE_EDITOR_ONLY)}
+        output, stats = run_normalize(
+            JANE_DOE_PREFACE, db, check_authors=True
+        )
+        entry = parse_first_entry(output)
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry["ID"], "janedoe")
+        self.assertIn("doe", extract_last_names(entry.get("author", "")))
+        self.assertNotIn("booktitle", entry)
+        self.assertEqual(stats["converted"], 0)
+        self.assertEqual(stats["skipped_author_mismatch"], 1)
+
+
+class TestDigitTitleKeys(unittest.TestCase):
+    def test_16x16_matches_16x16_not_32x32(self):
+        title_16 = "A 16x16 Convolution Network"
+        title_32 = "A 32x32 Convolution Network"
+        key_16 = normalize_title(title_16, keep_digits=True)
+        key_32 = normalize_title(title_32, keep_digits=True)
+        self.assertNotEqual(key_16, key_32)
+        self.assertEqual(
+            normalize_title(title_16, keep_digits=False),
+            normalize_title(title_32, keep_digits=False),
+        )
+        entry_16 = """@inproceedings{n16,
+  title={A 16x16 Convolution Network Official},
+  author={Ada Lovelace},
+  booktitle={TMLR},
+  year={2024}
+}
+"""
+        entry_32 = """@inproceedings{n32,
+  title={A 32x32 Convolution Network Official},
+  author={Ada Lovelace},
+  booktitle={COLM},
+  year={2024}
+}
+"""
+        db = {
+            key_16: _db_entry_lines(entry_16),
+            key_32: _db_entry_lines(entry_32),
+        }
+        input_bib = """@article{mine,
+  title={A 16x16 Convolution Network},
+  author={Ada Lovelace},
+  year={2024}
+}
+"""
+        output, stats = run_normalize(input_bib, db, check_authors=True)
+        entry = parse_first_entry(output)
+        self.assertIsNotNone(entry)
+        self.assertEqual(stats["converted"], 1)
+        self.assertIn("16x16", entry.get("title", ""))
+        self.assertNotIn("32x32", entry.get("title", ""))
+        self.assertEqual(entry.get("booktitle"), "TMLR")
+
+
+class TestPostProcessingCount(unittest.TestCase):
+    def test_count_mismatch_dumps_raw(self):
+        good = _db_entry_lines(
+            """@article{ok,
+  title={Ok},
+  author={Ada},
+  year={2020}
+}
+"""
+        )
+        bad = ["@article{broken,\n", "  title={No closing\n"]
+        output = post_processing([good, bad], [], [], sort=False)
+        self.assertIn("@article{ok", output.replace(" ", ""))
+        self.assertIn("broken", output)
+        self.assertIn("No closing", output)
 
 
 class TestBatchOutputPaths(unittest.TestCase):


### PR DESCRIPTION
Follow-up to 1.3.0 matching safety. No venue dump changes.

## What changed
- **Fail-closed author overlap.** Empty or missing authors on either side is no longer treated as a match. Editor-only front matter (e.g. a DBLP \"Preface\") cannot replace a paper with the same title.
- **`et al.` / `and others`.** Trailing abbreviated author lists are stripped before last-name compare so `De-An Huang et al.` still overlaps `Huang, De-An`.
- **Digit-preserving lookup.** Title match tries a key that keeps digits first (`16x16` ≠ `32x32`), then falls back to the letters-only key used by existing dumps.
- **Leftover buffer.** An unclosed entry at EOF is kept with a warning instead of being dropped.
- **`month=` only.** `bib2json` skips `month=` field assignments, not any line that merely contains the word \"month\".
- `post_processing` dumps the raw entries whenever the parsed count does not match (no `-5` slop).

Existing 1.3 guards still hold: Nature/\"Deep Learning\" is not swapped; published papers are not rewritten because an abstract mentions arXiv; unparsed entries are kept; unofficial arXiv still becomes `eprint`/`archivePrefix` form.

## Tests
- `tests/test_normalize.py`: et al. last names, fail-closed empty authors, 16×16 vs 32×32, leftover/post_processing dump.
- `tests/test_bib2json.py`: keep_digits keys, month in title, unclosed buffer.
- Local: `pytest tests -q --tb=short` → 60 passed.

Merge when pytest 3.9 + 3.12 is green.