### PR TITLE
Add a human-readable change report for replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ rebiber -i input.bib -o pretty.bib --format-only
 
 # report what would change without writing
 rebiber -i input.bib --dry-run
+
+# also write the change report to a file (always printed to stdout)
+rebiber -i input.bib --dry-run --report changes.txt
 ```
 
 You can find a pair of example input and output files in [`examples/input.bib`](examples/input.bib) and [`examples/output.bib`](examples/output.bib).
@@ -106,6 +109,7 @@ rebiber -i input.bib [more.bib ...] [-o out.bib|outdir]
   -st/--sort True|False (default False)
   --format-only   # pretty-print only, for diffs (issue 66)
   --dry-run       # report without writing
+  --report PATH   # also write the change report to PATH
   --no-check-authors  # disable author-overlap guard (issue 50)
   -u/--update
   -v/--version
@@ -123,6 +127,7 @@ rebiber -i input.bib [more.bib ...] [-o out.bib|outdir]
 | `-st` | or `--sort`. `True`/`False`, **False** by default. Keep the input order unless set to `True` (then entries are ordered alphabetically). Used as `-st True`. |
 | `--format-only` | Pretty-print / normalize formatting only. Do not replace entries with official DBLP/ACL records. Handy for reviewing diffs. |
 | `--dry-run` | Report conversions and issues without writing output files. |
+| `--report` | Optional path. Also write the human-readable change report (cite key, before/after venue, reason) to this file. The report is always printed to stdout. |
 | `--no-check-authors` | Disable the author-overlap guard (see below). |
 | `-l` | or `--bib_list`. The list of bib json files to load. Default: [rebiber/bib_list.txt](rebiber/bib_list.txt). |
 | `-a` | or `--abbr_tsv`. Conference abbreviation table. Default: [rebiber/abbr.tsv](rebiber/abbr.tsv). |

--- a/rebiber/normalize.py
+++ b/rebiber/normalize.py
@@ -218,6 +218,57 @@ def looks_published(entry):
     return False
 
 
+def entry_venue(entry_dict):
+    """Return journal or booktitle (first meaningful value), else empty string."""
+    if not entry_dict:
+        return ""
+    for field in ("journal", "booktitle"):
+        value = entry_dict.get(field)
+        if _meaningful_venue(value):
+            return str(value).strip()
+    return ""
+
+
+def format_change_report(rows):
+    """Format change rows as human-readable text. Pure: no I/O."""
+    lines = ["===== Changes ====="]
+    if not rows:
+        lines.append("(none)")
+        return "\n".join(lines) + "\n"
+    for row in rows:
+        cite_key = (row.get("cite_key") if row else None) or "<unknown>"
+        reason = (row.get("reason") if row else None) or ""
+        before = (row.get("before_venue") if row else None) or ""
+        after = (row.get("after_venue") if row else None) or ""
+        if after:
+            venue_part = "%s -> %s" % (before or "-", after)
+        elif before:
+            venue_part = before
+        else:
+            venue_part = "-"
+        if reason:
+            lines.append("%s: %s (%s)" % (cite_key, venue_part, reason))
+        else:
+            lines.append("%s: %s" % (cite_key, venue_part))
+    return "\n".join(lines) + "\n"
+
+
+def _change_row(cite_key, before_venue, after_venue, reason):
+    return {
+        "cite_key": cite_key or "",
+        "before_venue": before_venue or "",
+        "after_venue": after_venue or "",
+        "reason": reason or "",
+    }
+
+
+def _venue_from_lines(entry_lines):
+    parsed, _warning = parse_bib_entry(entry_lines)
+    if not parsed:
+        return ""
+    return entry_venue(parsed)
+
+
 def _normalize_arxiv_id(year_part, num_part):
     return "%s.%s" % (year_part, num_part)
 
@@ -410,6 +461,7 @@ def normalize_bib(
 
     output_bib_entries = []
     bib_keys = set()
+    changes = []
     stats = {
         "converted": 0,
         "skipped_author_mismatch": 0,
@@ -475,6 +527,14 @@ def normalize_bib(
                     )
                 )
                 stats["skipped_author_mismatch"] += 1
+                changes.append(
+                    _change_row(
+                        original_bibkey,
+                        entry_venue(parsed_entry),
+                        "",
+                        "author_mismatch",
+                    )
+                )
                 output_bib_entries.append(bib_entry)
                 continue
 
@@ -483,6 +543,14 @@ def normalize_bib(
                 "Converted. ID: %s ; Title: %s" % (original_bibkey, original_title)
             )
             stats["converted"] += 1
+            changes.append(
+                _change_row(
+                    original_bibkey,
+                    entry_venue(parsed_entry),
+                    _venue_from_lines(found_bibitem),
+                    "converted",
+                )
+            )
             output_bib_entries.append(found_bibitem)
             continue
 
@@ -505,13 +573,24 @@ def normalize_bib(
                 % (original_bibkey, original_title)
             )
             stats["arxiv_normalized"] += 1
+            changes.append(
+                _change_row(
+                    original_bibkey,
+                    entry_venue(parsed_entry),
+                    _venue_from_lines(bib_entry),
+                    "arxiv_normalized",
+                )
+            )
             output_bib_entries.append(bib_entry)
             continue
 
         output_bib_entries.append(bib_entry)
         stats["unchanged"] += 1
 
+    stats["changes"] = changes
+    stats["report"] = format_change_report(changes)
     print_summary(stats)
+    print(stats["report"], end="")
     output_string = post_processing(
         output_bib_entries, removed_value_names, abbr_dict, sort
     )
@@ -672,6 +751,13 @@ def build_parser(filepath=None):
         action="store_true",
         help="Print the conversion report but do not write output files.",
     )
+    parser.add_argument(
+        "--report",
+        metavar="PATH",
+        default=None,
+        type=str,
+        help="Optional file to also write the human-readable change report.",
+    )
     return parser
 
 
@@ -716,11 +802,12 @@ def main(argv=None):
     else:
         abbr_dict = []
 
+    reports = []
     for input_path, output_path in zip(input_paths, output_paths):
         if len(input_paths) > 1:
             print("----- Processing:", input_path, "->", output_path, "-----")
         all_bib_entries = load_bib_file(input_path)
-        normalize_bib(
+        stats = normalize_bib(
             bib_db,
             all_bib_entries,
             output_path,
@@ -732,6 +819,15 @@ def main(argv=None):
             format_only=args.format_only,
             dry_run=args.dry_run,
         )
+        reports.append(stats.get("report") or "")
+
+    if args.report:
+        report_dir = os.path.dirname(args.report)
+        if report_dir:
+            os.makedirs(report_dir, exist_ok=True)
+        with open(args.report, "w", encoding="utf8") as report_file:
+            report_file.write("".join(reports))
+        print("Report written to:", args.report)
 
 
 if __name__ == "__main__":

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -10,9 +10,12 @@ from rebiber.normalize import (
     authors_overlap,
     build_parser,
     construct_bib_db,
+    entry_venue,
     extract_arxiv_ids,
     extract_last_names,
+    format_change_report,
     looks_published,
+    main,
     normalize_bib,
     post_processing,
     str2bool,
@@ -502,6 +505,138 @@ class TestBatchOutputPaths(unittest.TestCase):
         self.assertEqual(
             resolve_output_path("a.bib", "same", num_inputs=2), "a.bib"
         )
+
+
+class TestChangeReport(unittest.TestCase):
+    def test_entry_venue_prefers_journal_then_booktitle(self):
+        self.assertEqual(entry_venue({"journal": "Nature"}), "Nature")
+        self.assertEqual(
+            entry_venue({"booktitle": "Proceedings of EMNLP"}),
+            "Proceedings of EMNLP",
+        )
+        self.assertEqual(
+            entry_venue({"journal": "Nature", "booktitle": "KDD"}),
+            "Nature",
+        )
+        self.assertEqual(entry_venue({"journal": " ~ "}), "")
+        self.assertEqual(entry_venue({}), "")
+        self.assertEqual(entry_venue(None), "")
+
+    def test_format_change_report_is_pure_and_readable(self):
+        text = format_change_report(
+            [
+                {
+                    "cite_key": "abc",
+                    "before_venue": "arXiv preprint",
+                    "after_venue": "EMNLP",
+                    "reason": "converted",
+                }
+            ]
+        )
+        self.assertIn("abc", text)
+        self.assertIn("arXiv preprint", text)
+        self.assertIn("EMNLP", text)
+        self.assertIn("converted", text)
+        empty = format_change_report([])
+        self.assertIn("Changes", empty)
+        self.assertIn("(none)", empty)
+
+    def test_converted_row_names_cite_key_and_venues(self):
+        output, stats = run_normalize(
+            SHARED_AUTHOR_DEEP_LEARNING, deep_learning_db(), check_authors=True
+        )
+        entry = parse_first_entry(output)
+        self.assertEqual(entry["ID"], "mydeeplearning")
+        self.assertEqual(stats["converted"], 1)
+        rows = stats["changes"]
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["cite_key"], "mydeeplearning")
+        self.assertEqual(row["reason"], "converted")
+        self.assertIn("arxiv", row["before_venue"].lower())
+        self.assertTrue(row["after_venue"])
+        self.assertIn("kdd", row["after_venue"].lower())
+        self.assertIn("mydeeplearning", stats["report"])
+        self.assertIn(row["before_venue"], stats["report"])
+        self.assertIn(row["after_venue"], stats["report"])
+
+    def test_author_mismatch_row(self):
+        output, stats = run_normalize(
+            NATURE_DEEP_LEARNING, deep_learning_db(), check_authors=True
+        )
+        entry = parse_first_entry(output)
+        self.assertEqual(entry.get("journal", "").lower(), "nature")
+        self.assertEqual(stats["skipped_author_mismatch"], 1)
+        rows = stats["changes"]
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["cite_key"], "deeplearning")
+        self.assertEqual(row["reason"], "author_mismatch")
+        self.assertEqual(row["before_venue"].lower(), "nature")
+        self.assertFalse(row["after_venue"])
+        self.assertIn("deeplearning", stats["report"])
+        self.assertIn("author_mismatch", stats["report"])
+
+    @patch("rebiber.normalize.fetch_arxiv_metadata", return_value={})
+    def test_arxiv_normalized_row(self, _mock):
+        output, stats = run_normalize(ARXIV_PREPRINT, {})
+        entry = parse_first_entry(output)
+        self.assertEqual(entry["ID"], "lin2020birds")
+        self.assertEqual(entry.get("eprint"), "2005.00683")
+        self.assertEqual(stats["arxiv_normalized"], 1)
+        rows = stats["changes"]
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["cite_key"], "lin2020birds")
+        self.assertEqual(row["reason"], "arxiv_normalized")
+        self.assertIn("arxiv", row["before_venue"].lower())
+        self.assertIn("lin2020birds", stats["report"])
+        self.assertIn("arxiv_normalized", stats["report"])
+
+    def test_dry_run_does_not_create_output_bib(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            entries, _inp = write_and_load(tmp, SHARED_AUTHOR_DEEP_LEARNING)
+            out_path = os.path.join(tmp, "out.bib")
+            stats = normalize_bib(
+                deep_learning_db(),
+                entries,
+                out_path,
+                check_authors=True,
+                dry_run=True,
+            )
+            self.assertFalse(os.path.isfile(out_path))
+            self.assertEqual(stats["converted"], 1)
+            self.assertTrue(stats["changes"])
+            self.assertIn("mydeeplearning", stats["report"])
+            self.assertIn("output", stats)
+
+    def test_cli_report_flag_and_file(self):
+        parser = build_parser()
+        args = parser.parse_args(["-i", "a.bib", "--report", "changes.txt"])
+        self.assertEqual(args.report, "changes.txt")
+        with tempfile.TemporaryDirectory() as tmp:
+            in_path = os.path.join(tmp, "in.bib")
+            with open(in_path, "w", encoding="utf8") as handle:
+                handle.write(NATURE_DEEP_LEARNING)
+            report_path = os.path.join(tmp, "subdir", "report.txt")
+            out_path = os.path.join(tmp, "out.bib")
+            main(
+                [
+                    "-i",
+                    in_path,
+                    "-o",
+                    out_path,
+                    "--format-only",
+                    "--dry-run",
+                    "--report",
+                    report_path,
+                ]
+            )
+            self.assertFalse(os.path.isfile(out_path))
+            self.assertTrue(os.path.isfile(report_path))
+            with open(report_path, encoding="utf8") as handle:
+                text = handle.read()
+            self.assertIn("Changes", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Depends on #73 (`matching-harden`). Please merge that first; this PR includes those commits until then.

## What changed
Users can inspect replacements without guessing.

- `normalize_bib` collects change rows on `stats["changes"]` and a formatted string on `stats["report"]`.
- Each converted / author-mismatch / arXiv-normalized entry records cite key, before venue, after venue (when applicable), and reason.
- `format_change_report(rows)` is a pure formatter. The report is printed after the existing summary.
- CLI `--report PATH` also writes the same text. `--dry-run` still writes no `.bib` file.
- Helper `entry_venue(entry_dict)` returns journal or booktitle (first meaningful).

## Tests
- `tests/test_normalize.py`: converted / author-mismatch / arXiv-normalized rows (field-level), dry-run does not create the output `.bib`, `--report` writes a file.
- Local: `pytest tests -q --tb=short` → 67 passed.

Merge when pytest 3.9 + 3.12 is green.