### PR TITLE
Filter replacements to cite keys used in .tex files

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ rebiber -i input.bib --dry-run
 
 # also write the change report to a file (always printed to stdout)
 rebiber -i input.bib --dry-run --report changes.txt
+
+# only convert entries cited in these .tex files (others stay unchanged)
+rebiber -i input.bib --used-in paper.tex appendix.tex
 ```
 
 You can find a pair of example input and output files in [`examples/input.bib`](examples/input.bib) and [`examples/output.bib`](examples/output.bib).
@@ -110,6 +113,7 @@ rebiber -i input.bib [more.bib ...] [-o out.bib|outdir]
   --format-only   # pretty-print only, for diffs (issue 66)
   --dry-run       # report without writing
   --report PATH   # also write the change report to PATH
+  --used-in FILE [FILE ...]  # only convert keys cited in these .tex files
   --no-check-authors  # disable author-overlap guard (issue 50)
   -u/--update
   -v/--version
@@ -128,6 +132,7 @@ rebiber -i input.bib [more.bib ...] [-o out.bib|outdir]
 | `--format-only` | Pretty-print / normalize formatting only. Do not replace entries with official DBLP/ACL records. Handy for reviewing diffs. |
 | `--dry-run` | Report conversions and issues without writing output files. |
 | `--report` | Optional path. Also write the human-readable change report (cite key, before/after venue, reason) to this file. The report is always printed to stdout. |
+| `--used-in` | One or more `.tex` files. Only convert or arXiv-normalize bib entries whose cite keys appear in `\\cite` / `\\citep` / `\\citet` / `\\citealp` / `\\citeyear` / `\\nocite` (starred and optional-arg forms included). Unused keys are left unchanged. |
 | `--no-check-authors` | Disable the author-overlap guard (see below). |
 | `-l` | or `--bib_list`. The list of bib json files to load. Default: [rebiber/bib_list.txt](rebiber/bib_list.txt). |
 | `-a` | or `--abbr_tsv`. Conference abbreviation table. Default: [rebiber/abbr.tsv](rebiber/abbr.tsv). |

--- a/rebiber/normalize.py
+++ b/rebiber/normalize.py
@@ -269,6 +269,43 @@ def _venue_from_lines(entry_lines):
     return entry_venue(parsed)
 
 
+_CITE_COMMAND_RE = re.compile(
+    r"\\(?:cite|citep|citet|citealp|citeyear|nocite)\s*\*?"
+    r"(?:\s*\[[^\]]*\]){0,2}\s*\{([^}]*)\}",
+    re.IGNORECASE,
+)
+
+
+def extract_cite_keys_from_tex(text):
+    """Parse cite keys from LaTeX citation commands.
+
+    Supports ``\\cite``, ``\\citep``, ``\\citet``, ``\\citealp``, ``\\citeyear``,
+    and ``\\nocite``, including starred and optional-argument variants.
+    Comma-separated lists are split. A bare ``*`` (as in ``\\nocite{*}``) is
+    ignored rather than treated as a cite key.
+    """
+    if not text:
+        return set()
+    keys = set()
+    for match in _CITE_COMMAND_RE.finditer(text):
+        inner = match.group(1) or ""
+        for part in inner.split(","):
+            key = part.strip()
+            if not key or key == "*":
+                continue
+            keys.add(key)
+    return keys
+
+
+def extract_cite_keys_from_tex_files(paths):
+    """Read ``.tex`` files and return the union of their cite keys."""
+    keys = set()
+    for path in paths or []:
+        with open(path, encoding="utf8") as handle:
+            keys |= extract_cite_keys_from_tex(handle.read())
+    return keys
+
+
 def _normalize_arxiv_id(year_part, num_part):
     return "%s.%s" % (year_part, num_part)
 
@@ -453,6 +490,7 @@ def normalize_bib(
     check_authors=True,
     format_only=False,
     dry_run=False,
+    used_keys=None,
 ):
     removed_value_names = list(removed_value_names or [])
     abbr_dict = list(abbr_dict or [])
@@ -501,6 +539,11 @@ def normalize_bib(
             bib_keys.add(original_bibkey)
 
         if format_only:
+            output_bib_entries.append(bib_entry)
+            stats["unchanged"] += 1
+            continue
+
+        if used_keys is not None and original_bibkey not in used_keys:
             output_bib_entries.append(bib_entry)
             stats["unchanged"] += 1
             continue
@@ -758,6 +801,14 @@ def build_parser(filepath=None):
         type=str,
         help="Optional file to also write the human-readable change report.",
     )
+    parser.add_argument(
+        "--used-in",
+        nargs="+",
+        metavar="FILE",
+        default=None,
+        help="Only convert or arXiv-normalize entries whose cite keys appear "
+        "in these .tex files. Unused bib keys are left unchanged.",
+    )
     return parser
 
 
@@ -802,6 +853,10 @@ def main(argv=None):
     else:
         abbr_dict = []
 
+    used_keys = None
+    if args.used_in:
+        used_keys = extract_cite_keys_from_tex_files(args.used_in)
+
     reports = []
     for input_path, output_path in zip(input_paths, output_paths):
         if len(input_paths) > 1:
@@ -818,6 +873,7 @@ def main(argv=None):
             check_authors=not args.no_check_authors,
             format_only=args.format_only,
             dry_run=args.dry_run,
+            used_keys=used_keys,
         )
         reports.append(stats.get("report") or "")
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -12,6 +12,8 @@ from rebiber.normalize import (
     construct_bib_db,
     entry_venue,
     extract_arxiv_ids,
+    extract_cite_keys_from_tex,
+    extract_cite_keys_from_tex_files,
     extract_last_names,
     format_change_report,
     looks_published,
@@ -637,6 +639,172 @@ class TestChangeReport(unittest.TestCase):
             with open(report_path, encoding="utf8") as handle:
                 text = handle.read()
             self.assertIn("Changes", text)
+
+
+TWO_PAPER_INPUT = """@article{alpha,
+  title={Alpha Unique Title},
+  author={Ada Lovelace},
+  journal={arXiv preprint arXiv:2001.00001},
+  year={2020}
+}
+
+@article{beta,
+  title={Beta Unique Title},
+  author={Alan Turing},
+  journal={arXiv preprint arXiv:2002.00002},
+  year={2020}
+}
+"""
+
+
+def two_paper_db():
+    entry_a = """@inproceedings{p1,
+  title={Alpha Unique Title},
+  author={Ada Lovelace},
+  booktitle={ICML},
+  year={2020}
+}
+"""
+    entry_b = """@inproceedings{p2,
+  title={Beta Unique Title},
+  author={Alan Turing},
+  booktitle={NeurIPS},
+  year={2020}
+}
+"""
+    return {
+        normalize_title("Alpha Unique Title"): _db_entry_lines(entry_a),
+        normalize_title("Beta Unique Title"): _db_entry_lines(entry_b),
+    }
+
+
+class TestExtractCiteKeys(unittest.TestCase):
+    def test_cite_comma_list(self):
+        self.assertEqual(extract_cite_keys_from_tex(r"\cite{a,b}"), {"a", "b"})
+        self.assertEqual(extract_cite_keys_from_tex(r"\cite{a, b, c}"), {"a", "b", "c"})
+
+    def test_citep_optional_arg(self):
+        self.assertEqual(extract_cite_keys_from_tex(r"\citep[p.1]{c}"), {"c"})
+        self.assertEqual(
+            extract_cite_keys_from_tex(r"\citep[see][p.1]{opt}"), {"opt"}
+        )
+
+    def test_starred_and_other_macros(self):
+        text = r"\cite*{starred} \citet{d} \citealp{e} \citeyear{f}"
+        self.assertEqual(
+            extract_cite_keys_from_tex(text), {"starred", "d", "e", "f"}
+        )
+
+    def test_nocite_star_ignored(self):
+        self.assertEqual(extract_cite_keys_from_tex(r"\nocite{*}"), set())
+        self.assertEqual(
+            extract_cite_keys_from_tex(r"\nocite{keepme} \nocite{*}"),
+            {"keepme"},
+        )
+
+    def test_extract_from_tex_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "paper.tex")
+            with open(path, "w", encoding="utf8") as handle:
+                handle.write(r"See \cite{a,b} and \citep[p.1]{c}." + "\n")
+            extra = os.path.join(tmp, "app.tex")
+            with open(extra, "w", encoding="utf8") as handle:
+                handle.write(r"\citet{d}" + "\n")
+            self.assertEqual(
+                extract_cite_keys_from_tex_files([path, extra]),
+                {"a", "b", "c", "d"},
+            )
+
+
+class TestUsedInFilter(unittest.TestCase):
+    def test_unused_entries_stay_unchanged(self):
+        output, stats = run_normalize(
+            TWO_PAPER_INPUT,
+            two_paper_db(),
+            check_authors=True,
+            used_keys={"alpha"},
+        )
+        parsed = bibtexparser.loads(output)
+        by_id = {entry["ID"]: entry for entry in parsed.entries}
+        self.assertEqual(by_id["alpha"].get("booktitle"), "ICML")
+        self.assertIn("lovelace", extract_last_names(by_id["alpha"].get("author", "")))
+        self.assertEqual(
+            by_id["beta"].get("journal"), "arXiv preprint arXiv:2002.00002"
+        )
+        self.assertIn("turing", extract_last_names(by_id["beta"].get("author", "")))
+        self.assertNotIn("booktitle", by_id["beta"])
+        self.assertEqual(stats["converted"], 1)
+        self.assertEqual(stats["unchanged"], 1)
+
+    def test_used_entries_still_convert(self):
+        output, stats = run_normalize(
+            TWO_PAPER_INPUT,
+            two_paper_db(),
+            check_authors=True,
+            used_keys={"alpha", "beta"},
+        )
+        parsed = bibtexparser.loads(output)
+        by_id = {entry["ID"]: entry for entry in parsed.entries}
+        self.assertEqual(by_id["alpha"].get("booktitle"), "ICML")
+        self.assertEqual(by_id["beta"].get("booktitle"), "NeurIPS")
+        self.assertEqual(stats["converted"], 2)
+        self.assertEqual(stats["unchanged"], 0)
+
+    def test_empty_used_keys_converts_nothing(self):
+        output, stats = run_normalize(
+            TWO_PAPER_INPUT,
+            two_paper_db(),
+            check_authors=True,
+            used_keys=set(),
+        )
+        parsed = bibtexparser.loads(output)
+        by_id = {entry["ID"]: entry for entry in parsed.entries}
+        self.assertEqual(
+            by_id["alpha"].get("journal"), "arXiv preprint arXiv:2001.00001"
+        )
+        self.assertEqual(
+            by_id["beta"].get("journal"), "arXiv preprint arXiv:2002.00002"
+        )
+        self.assertEqual(stats["converted"], 0)
+        self.assertEqual(stats["arxiv_normalized"], 0)
+        self.assertEqual(stats["unchanged"], 2)
+
+    def test_none_used_keys_keeps_current_behavior(self):
+        output, stats = run_normalize(
+            TWO_PAPER_INPUT,
+            two_paper_db(),
+            check_authors=True,
+            used_keys=None,
+        )
+        self.assertEqual(stats["converted"], 2)
+
+    def test_cli_used_in_flag(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            ["-i", "a.bib", "--used-in", "paper.tex", "extra.tex"]
+        )
+        self.assertEqual(args.used_in, ["paper.tex", "extra.tex"])
+
+    @patch("rebiber.normalize.fetch_arxiv_metadata", return_value={})
+    def test_unused_arxiv_not_normalized(self, mock_fetch):
+        output, stats = run_normalize(
+            ARXIV_PREPRINT, {}, used_keys={"someoneelse"}
+        )
+        entry = parse_first_entry(output)
+        self.assertEqual(entry.get("journal"), "arXiv preprint arXiv:2005.00683")
+        self.assertNotIn("eprint", entry)
+        self.assertEqual(stats["arxiv_normalized"], 0)
+        self.assertEqual(stats["unchanged"], 1)
+        mock_fetch.assert_not_called()
+
+    @patch("rebiber.normalize.fetch_arxiv_metadata", return_value={})
+    def test_used_arxiv_still_normalized(self, _mock):
+        output, stats = run_normalize(
+            ARXIV_PREPRINT, {}, used_keys={"lin2020birds"}
+        )
+        entry = parse_first_entry(output)
+        self.assertEqual(entry.get("eprint"), "2005.00683")
+        self.assertEqual(stats["arxiv_normalized"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Depends on #73 (`matching-harden`) and #74 (`feature-change-report`). Please merge those first; this PR includes their commits until then.

## What changed
- `extract_cite_keys_from_tex(text)` parses `\\cite`, `\\citep`, `\\citet`, `\\citealp`, `\\citeyear`, `\\nocite` plus starred/optional-arg variants, and splits comma lists. `\\nocite{*}` ignores `*`.
- `extract_cite_keys_from_tex_files(paths)` reads files and unions keys.
- CLI `--used-in FILE [FILE ...]`: when set, only used cite keys are converted or arXiv-normalized. Unused bib keys are left unchanged (count as unchanged).
- `normalize_bib(..., used_keys=None)`. `None` keeps current behavior (all keys). An empty set converts nothing.

## Tests
- Extractor unit tests: `\\cite{a,b}`, `\\citep[p.1]{c}`, `\\nocite{*}`.
- Unused entries keep the same venue/authors; used entries still convert; unused arXiv is not rewritten.
- Local: `pytest tests -q --tb=short` → 79 passed.

Merge when pytest 3.9 + 3.12 is green.