### PR TITLE
Add opt-in live DBLP lookup and preserve preprint eprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Apart from handling outdated arXiv citations, __Rebiber__ also normalizes citati
 
 ## Changelog
 
+- **2026.08** Opt-in `--live-lookup`: after a local-index miss, search DBLP by title and apply a hit only when title keys and authors overlap (same guard as local matches). Official replacements keep the input cite key and preserve an input arXiv/`eprint` when the published record lacks one. Default CLI stays local-only (no network). Please respect DBLP rate limits.
+
 - **2026.08** Venue dumps: robotics main tracks (ICRA/IROS/RSS/CoRL), TMLR, WACV, JMLR 2023–26, MLSys 2022–25, KDD 2025, full NeurIPS 2025 (~5.8k). Downloader now paginates past DBLP's 100-hit cap, supports journal tocs and multi-volume KDD/MICCAI/ECCV. No workshop dumps.
 
 - **2026.08** Version **1.3.0**. Safer title matching (author-overlap guard so a "Deep Learning" book/Nature paper is not replaced by an unrelated KDD talk); official arXiv fields (`eprint`, `archivePrefix`, `primaryClass`); do not rewrite already-published papers just because an abstract mentions arXiv; do not silently drop unparsed entries; `--format-only` / `--dry-run` / `--no-check-authors`; batch inputs (`rebiber -i *.bib`); conference data through 2025–2026 (AAAI, ICLR, ICML, NeurIPS, CVPR, ICCV, CHI, WWW, SIGIR, IJCAI, KDD, Interspeech, ICASSP, AISTATS, UAI, BMVC, ACL Anthology); monthly GitHub Action to refresh DBLP + ACL anthology; more `booktitle` abbreviations (COLM, WACV, ECCV, ICCV, NAACL, Findings, TACL, JMLR).
@@ -100,6 +102,9 @@ rebiber -i input.bib --dry-run --report changes.txt
 
 # only convert entries cited in these .tex files (others stay unchanged)
 rebiber -i input.bib --used-in paper.tex appendix.tex
+
+# opt-in live DBLP search for local-index misses (uses network; rate-limited)
+rebiber -i input.bib --live-lookup
 ```
 
 You can find a pair of example input and output files in [`examples/input.bib`](examples/input.bib) and [`examples/output.bib`](examples/output.bib).
@@ -114,6 +119,7 @@ rebiber -i input.bib [more.bib ...] [-o out.bib|outdir]
   --dry-run       # report without writing
   --report PATH   # also write the change report to PATH
   --used-in FILE [FILE ...]  # only convert keys cited in these .tex files
+  --live-lookup   # opt-in DBLP title search on local misses (uses network)
   --no-check-authors  # disable author-overlap guard (issue 50)
   -u/--update
   -v/--version
@@ -133,6 +139,7 @@ rebiber -i input.bib [more.bib ...] [-o out.bib|outdir]
 | `--dry-run` | Report conversions and issues without writing output files. |
 | `--report` | Optional path. Also write the human-readable change report (cite key, before/after venue, reason) to this file. The report is always printed to stdout. |
 | `--used-in` | One or more `.tex` files. Only convert or arXiv-normalize bib entries whose cite keys appear in `\\cite` / `\\citep` / `\\citet` / `\\citealp` / `\\citeyear` / `\\nocite` (starred and optional-arg forms included). Unused keys are left unchanged. |
+| `--live-lookup` | Opt-in. After a local-index miss, query DBLP's publication search by title and replace the entry if the title key and authors overlap. Timeout / HTTP errors / no hit keep the original entry. **Off by default** (no network). Please respect [DBLP's rate limits](https://dblp.org/faq/How+to+use+the+dblp+search+API.html); do not run this on huge bib files in a tight loop. |
 | `--no-check-authors` | Disable the author-overlap guard (see below). |
 | `-l` | or `--bib_list`. The list of bib json files to load. Default: [rebiber/bib_list.txt](rebiber/bib_list.txt). |
 | `-a` | or `--abbr_tsv`. Conference abbreviation table. Default: [rebiber/abbr.tsv](rebiber/abbr.tsv). |
@@ -143,6 +150,7 @@ rebiber -i input.bib [more.bib ...] [-o out.bib|outdir]
 
 - **Author-overlap guard.** A title-only match is not enough when the candidate official record looks like a different paper. Rebiber will not replace a "Deep Learning" book or *Nature* article with an unrelated KDD talk that happens to share a short/generic title. Use `--no-check-authors` only if you want the old title-only behavior. Empty or missing authors on either side is **not** treated as a match (fail-closed), so editor-only front-matter such as a "Preface" will not replace a paper by that title. Trailing `et al.` / `and others` is stripped before last-name compare.
 - **Digit-preserving title keys.** Lookup first tries a key that keeps digits (`16x16` ≠ `32x32`) and falls back to the letters-only key used by older dumps.
+- **Opt-in live DBLP fallback.** With `--live-lookup`, a local miss does one DBLP title search (max 5 hits). A hit is applied only when the title key matches (digit key, then letters-only) **and** authors overlap. The user's cite key is kept. If the input was an arXiv preprint and the official record has no `eprint`, the input arXiv id is copied onto the published entry. Network failures do not crash the run. Default remains offline.
 - **Unclosed braces.** A leftover buffer at end-of-file is kept with a warning instead of being dropped.
 - **ArXiv official fields.** Unofficial arXiv preprints are rewritten with standard fields (`eprint`, `archivePrefix`, `primaryClass`) instead of a free-form `journal = {arXiv preprint ...}` string.
 - **Published papers stay published.** Rebiber will not rewrite an already-published entry just because the abstract (or another field) mentions arXiv.

--- a/rebiber/normalize.py
+++ b/rebiber/normalize.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import tempfile
 import urllib.error
+import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 import zipfile
@@ -38,6 +39,8 @@ CITEKEY_ARXIV_RE = re.compile(
 )
 ARXIV_VENUE_RE = re.compile(r"arxiv|\bcorr\b|preprint", re.IGNORECASE)
 PLACEHOLDER_VENUE_RE = re.compile(r"^[\s~\-{}]*$")
+DBLP_API = "https://dblp.org/search/publ/api"
+REBIBER_USER_AGENT = "rebiber/1.3.0 (+https://github.com/yuchenlin/rebiber)"
 
 
 def str2bool(value):
@@ -306,6 +309,162 @@ def extract_cite_keys_from_tex_files(paths):
     return keys
 
 
+def _split_bib_entries_from_text(text):
+    """Split concatenated BibTeX into list-of-lines entries (DBLP-style)."""
+    if not text:
+        return []
+    if isinstance(text, bytes):
+        text = text.decode("utf-8", errors="replace")
+    entries = []
+    buffer = []
+    brace_count = 0
+    started = False
+    for raw_line in text.splitlines(True):
+        line = raw_line if raw_line.endswith("\n") else raw_line + "\n"
+        stripped = line.lstrip()
+        if not started:
+            if stripped.startswith("@"):
+                started = True
+            else:
+                continue
+        buffer.append(line)
+        brace_count += line.count("{") - line.count("}")
+        if started and brace_count <= 0 and buffer:
+            entries.append(buffer)
+            buffer = []
+            started = False
+            brace_count = 0
+    if buffer:
+        entries.append(buffer)
+    return entries
+
+
+def _as_entry_lines(hit):
+    if hit is None:
+        return []
+    if isinstance(hit, list):
+        return list(hit)
+    return _split_bib_entries_from_text(str(hit))[:1] or [
+        line if line.endswith("\n") else line + "\n"
+        for line in str(hit).splitlines(True)
+    ]
+
+
+def search_dblp_by_title(title, timeout=10, opener=None):
+    """Query DBLP for ``title``. Returns a list of entry line-lists. Never raises."""
+    if not title or not str(title).strip():
+        return []
+    query = "%s?q=%s&format=bibtex&h=5" % (
+        DBLP_API,
+        urllib.parse.quote(str(title).strip()),
+    )
+    try:
+        request = urllib.request.Request(
+            query, headers={"User-Agent": REBIBER_USER_AGENT}
+        )
+        open_fn = opener or urllib.request.urlopen
+        with open_fn(request, timeout=timeout) as response:
+            payload = response.read()
+        return _split_bib_entries_from_text(payload)
+    except Exception as exc:
+        print(
+            "WARNING: DBLP search failed for %r (%s); continuing without live lookup."
+            % (title, exc)
+        )
+        return []
+
+
+def select_dblp_hit(input_entry, hit_entries, check_authors=True):
+    """Pick the first DBLP hit whose title key and authors match.
+
+    Title match tries the digit-preserving key first, then letters-only.
+    Returns chosen hit entry lines or None.
+    """
+    if not input_entry or not hit_entries:
+        return None
+    if isinstance(hit_entries, str):
+        hit_entries = [hit_entries]
+    input_title = input_entry.get("title") or ""
+    if not input_title:
+        return None
+    key_new = normalize_title(input_title, keep_digits=True)
+    key_old = normalize_title(input_title, keep_digits=False)
+    input_authors = input_entry.get("author")
+    for hit in hit_entries:
+        lines = _as_entry_lines(hit)
+        if not lines:
+            continue
+        parsed, _warning = parse_bib_entry(lines)
+        if not parsed or "title" not in parsed:
+            continue
+        hit_new = normalize_title(parsed["title"], keep_digits=True)
+        hit_old = normalize_title(parsed["title"], keep_digits=False)
+        if key_new and key_new == hit_new:
+            title_match = True
+        elif key_old and key_old == hit_old:
+            title_match = True
+        else:
+            title_match = False
+        if not title_match:
+            continue
+        if check_authors and not authors_overlap(input_authors, parsed.get("author")):
+            continue
+        return lines
+    return None
+
+
+def preserve_eprint(output_lines, input_entry):
+    """Copy input arXiv eprint onto an official record that lacks one."""
+    if not output_lines or not input_entry:
+        return list(output_lines) if output_lines else output_lines
+    arxiv_ids = extract_arxiv_ids(input_entry)
+    arxiv_id = None
+    if len(arxiv_ids) == 1:
+        arxiv_id = next(iter(arxiv_ids))
+    elif input_entry.get("eprint"):
+        eprint_text = str(input_entry.get("eprint")).strip()
+        bare = BARE_ARXIV_ID_RE.match(eprint_text)
+        if bare:
+            arxiv_id = bare.group(1)
+    if not arxiv_id:
+        return list(output_lines)
+
+    parsed, _warning = parse_bib_entry(output_lines)
+    if parsed and parsed.get("eprint"):
+        return list(output_lines)
+    for line in output_lines:
+        if re.match(r"\s*eprint\s*=", line, flags=re.IGNORECASE):
+            return list(output_lines)
+
+    has_archive = bool(parsed and parsed.get("archiveprefix"))
+    if not has_archive:
+        for line in output_lines:
+            if re.match(r"\s*archiveprefix\s*=", line, flags=re.IGNORECASE):
+                has_archive = True
+                break
+    insert = []
+    if not has_archive:
+        insert.append("  archivePrefix={arXiv},\n")
+    insert.append("  eprint={%s},\n" % arxiv_id)
+
+    new_lines = list(output_lines)
+    for idx in range(len(new_lines) - 1, -1, -1):
+        if "}" in new_lines[idx]:
+            if idx > 0:
+                prev = new_lines[idx - 1]
+                stripped = prev.rstrip("\n")
+                if (
+                    stripped
+                    and not stripped.rstrip().endswith(",")
+                    and not stripped.lstrip().startswith("@")
+                ):
+                    new_lines[idx - 1] = stripped + ",\n"
+            new_lines[idx:idx] = insert
+            return new_lines
+    new_lines.extend(insert)
+    return new_lines
+
+
 def _normalize_arxiv_id(year_part, num_part):
     return "%s.%s" % (year_part, num_part)
 
@@ -345,7 +504,7 @@ def fetch_arxiv_metadata(arxiv_id, timeout=5):
     url = "http://export.arxiv.org/api/query?id_list=%s&max_results=1" % arxiv_id
     try:
         request = urllib.request.Request(
-            url, headers={"User-Agent": "rebiber/1.3.0 (+https://github.com/yuchenlin/rebiber)"}
+            url, headers={"User-Agent": REBIBER_USER_AGENT}
         )
         with urllib.request.urlopen(request, timeout=timeout) as response:
             payload = response.read()
@@ -491,6 +650,8 @@ def normalize_bib(
     format_only=False,
     dry_run=False,
     used_keys=None,
+    live_lookup=False,
+    dblp_search=None,
 ):
     removed_value_names = list(removed_value_names or [])
     abbr_dict = list(abbr_dict or [])
@@ -596,6 +757,38 @@ def normalize_bib(
             )
             output_bib_entries.append(found_bibitem)
             continue
+
+        if live_lookup:
+            search_fn = dblp_search or search_dblp_by_title
+            try:
+                hits = search_fn(original_title)
+            except Exception as exc:
+                print(
+                    "WARNING: DBLP search failed for %r (%s); continuing without live lookup."
+                    % (original_title, exc)
+                )
+                hits = []
+            hit_lines = select_dblp_hit(
+                parsed_entry, hits, check_authors=check_authors
+            )
+            if hit_lines:
+                hit_lines = preserve_eprint(hit_lines, parsed_entry)
+                found_bibitem = replace_citation_key(hit_lines, original_bibkey)
+                print(
+                    "Converted (live DBLP). ID: %s ; Title: %s"
+                    % (original_bibkey, original_title)
+                )
+                stats["converted"] += 1
+                changes.append(
+                    _change_row(
+                        original_bibkey,
+                        entry_venue(parsed_entry),
+                        _venue_from_lines(found_bibitem),
+                        "converted_live",
+                    )
+                )
+                output_bib_entries.append(found_bibitem)
+                continue
 
         arxiv_ids = extract_arxiv_ids(parsed_entry)
         if len(arxiv_ids) > 1:
@@ -809,6 +1002,12 @@ def build_parser(filepath=None):
         help="Only convert or arXiv-normalize entries whose cite keys appear "
         "in these .tex files. Unused bib keys are left unchanged.",
     )
+    parser.add_argument(
+        "--live-lookup",
+        action="store_true",
+        help="On local-index miss, search DBLP by title (opt-in; uses network). "
+        "Respect DBLP rate limits; default is local-only / offline.",
+    )
     return parser
 
 
@@ -874,6 +1073,7 @@ def main(argv=None):
             format_only=args.format_only,
             dry_run=args.dry_run,
             used_keys=used_keys,
+            live_lookup=args.live_lookup,
         )
         reports.append(stats.get("report") or "")
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -7,6 +7,8 @@ import bibtexparser
 
 from rebiber.bib2json import load_bib_file, normalize_title
 from rebiber.normalize import (
+    DBLP_API,
+    REBIBER_USER_AGENT,
     authors_overlap,
     build_parser,
     construct_bib_db,
@@ -19,7 +21,11 @@ from rebiber.normalize import (
     looks_published,
     main,
     normalize_bib,
+    parse_bib_entry,
     post_processing,
+    preserve_eprint,
+    search_dblp_by_title,
+    select_dblp_hit,
     str2bool,
 )
 
@@ -805,6 +811,272 @@ class TestUsedInFilter(unittest.TestCase):
         entry = parse_first_entry(output)
         self.assertEqual(entry.get("eprint"), "2005.00683")
         self.assertEqual(stats["arxiv_normalized"], 1)
+
+
+LIVE_UNIQUE_TITLE = "A Completely Unique Live Lookup Title That Is Not In Any Dump"
+LIVE_PREPRINT_INPUT = """@article{mylivekey,
+  title={A Completely Unique Live Lookup Title That Is Not In Any Dump},
+  author={Ada Lovelace},
+  journal={arXiv preprint arXiv:2101.01234},
+  year={2021},
+  eprint={2101.01234},
+  archivePrefix={arXiv}
+}
+"""
+LIVE_WORKSHOP_INPUT = """@article{mylivekey,
+  title={A Completely Unique Live Lookup Title That Is Not In Any Dump},
+  author={Ada Lovelace},
+  journal={Some Workshop Notes},
+  year={2021}
+}
+"""
+
+
+def live_official_lines(with_eprint=False):
+    extra = ""
+    year_comma = ""
+    if with_eprint:
+        year_comma = ","
+        extra = "  archivePrefix={arXiv},\n  eprint={9999.99999},\n"
+    entry = """@inproceedings{dblpkey,
+  title={A Completely Unique Live Lookup Title That Is Not In Any Dump},
+  author={Ada Lovelace},
+  booktitle={Proceedings of the 38th International Conference on Machine Learning},
+  year={2021}%s
+%s}
+""" % (year_comma, extra)
+    return _db_entry_lines(entry)
+
+
+class TestLiveDblpLookup(unittest.TestCase):
+    def test_local_miss_converts_from_mock_dblp(self):
+        calls = []
+
+        def mock_search(title, timeout=10, opener=None):
+            calls.append(title)
+            return [live_official_lines()]
+
+        output, stats = run_normalize(
+            LIVE_PREPRINT_INPUT,
+            {},
+            live_lookup=True,
+            dblp_search=mock_search,
+        )
+        entry = parse_first_entry(output)
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry["ID"], "mylivekey")
+        self.assertIn(
+            "International Conference on Machine Learning",
+            entry.get("booktitle", ""),
+        )
+        self.assertIn("lovelace", extract_last_names(entry.get("author", "")))
+        self.assertEqual(stats["converted"], 1)
+        self.assertEqual(stats["arxiv_normalized"], 0)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("Unique Live Lookup", calls[0])
+        rows = stats["changes"]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["cite_key"], "mylivekey")
+        self.assertEqual(rows[0]["reason"], "converted_live")
+        self.assertIn("machine learning", rows[0]["after_venue"].lower())
+
+    def test_empty_hits_keep_original(self):
+        def mock_search(title, timeout=10, opener=None):
+            return []
+
+        output, stats = run_normalize(
+            LIVE_WORKSHOP_INPUT,
+            {},
+            live_lookup=True,
+            dblp_search=mock_search,
+        )
+        entry = parse_first_entry(output)
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry["ID"], "mylivekey")
+        self.assertEqual(entry.get("journal"), "Some Workshop Notes")
+        self.assertNotIn("booktitle", entry)
+        self.assertEqual(stats["converted"], 0)
+        self.assertEqual(stats["unchanged"], 1)
+
+    def test_raising_dblp_search_keeps_original(self):
+        def boom(title, timeout=10, opener=None):
+            raise RuntimeError("simulated network failure")
+
+        output, stats = run_normalize(
+            LIVE_WORKSHOP_INPUT,
+            {},
+            live_lookup=True,
+            dblp_search=boom,
+        )
+        entry = parse_first_entry(output)
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.get("journal"), "Some Workshop Notes")
+        self.assertEqual(stats["converted"], 0)
+        self.assertEqual(stats["unchanged"], 1)
+
+    def test_search_dblp_by_title_opener_timeout_returns_empty(self):
+        def boom(request, timeout=None):
+            raise TimeoutError("simulated timeout")
+
+        self.assertEqual(
+            search_dblp_by_title(LIVE_UNIQUE_TITLE, opener=boom), []
+        )
+
+    def test_search_dblp_by_title_uses_api_and_user_agent(self):
+        captured = {}
+
+        class FakeResp(object):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return (
+                    b"@inproceedings{x,\n"
+                    b"  title={A Completely Unique Live Lookup Title That Is Not In Any Dump},\n"
+                    b"  author={Ada Lovelace},\n"
+                    b"  booktitle={ICML},\n"
+                    b"  year={2021}\n"
+                    b"}\n"
+                )
+
+        def fake_open(request, timeout=None):
+            captured["url"] = request.full_url
+            captured["ua"] = request.get_header("User-agent") or request.headers.get(
+                "User-Agent"
+            )
+            captured["timeout"] = timeout
+            return FakeResp()
+
+        hits = search_dblp_by_title(LIVE_UNIQUE_TITLE, opener=fake_open)
+        self.assertTrue(hits)
+        self.assertIn(DBLP_API, captured["url"])
+        self.assertIn("format=bibtex", captured["url"])
+        self.assertIn("h=5", captured["url"])
+        self.assertEqual(captured["ua"], REBIBER_USER_AGENT)
+        parsed, _warning = parse_bib_entry(hits[0])
+        self.assertEqual(parsed.get("booktitle"), "ICML")
+
+    def test_eprint_preserved_when_official_lacks_it(self):
+        def mock_search(title, timeout=10, opener=None):
+            return [live_official_lines(with_eprint=False)]
+
+        output, stats = run_normalize(
+            LIVE_PREPRINT_INPUT,
+            {},
+            live_lookup=True,
+            dblp_search=mock_search,
+        )
+        entry = parse_first_entry(output)
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry["ID"], "mylivekey")
+        self.assertIn(
+            "International Conference on Machine Learning",
+            entry.get("booktitle", ""),
+        )
+        self.assertEqual(entry.get("eprint"), "2101.01234")
+        self.assertEqual(entry.get("archiveprefix"), "arXiv")
+        self.assertEqual(stats["converted"], 1)
+        # Direct helper: official already has eprint -> leave it.
+        kept = preserve_eprint(
+            live_official_lines(with_eprint=True),
+            {
+                "title": LIVE_UNIQUE_TITLE,
+                "eprint": "2101.01234",
+                "journal": "arXiv preprint arXiv:2101.01234",
+            },
+        )
+        parsed_kept = parse_first_entry("".join(kept))
+        self.assertEqual(parsed_kept.get("eprint"), "9999.99999")
+
+    def test_default_live_lookup_false_never_calls_spy(self):
+        calls = []
+
+        def spy(title, timeout=10, opener=None):
+            calls.append(title)
+            raise AssertionError("dblp_search must not be invoked by default")
+
+        output, stats = run_normalize(
+            LIVE_WORKSHOP_INPUT, {}, dblp_search=spy
+        )
+        self.assertEqual(calls, [])
+        entry = parse_first_entry(output)
+        self.assertEqual(entry.get("journal"), "Some Workshop Notes")
+        self.assertEqual(stats["converted"], 0)
+        self.assertEqual(stats["unchanged"], 1)
+
+        output_false, stats_false = run_normalize(
+            LIVE_WORKSHOP_INPUT,
+            {},
+            live_lookup=False,
+            dblp_search=spy,
+        )
+        self.assertEqual(calls, [])
+        self.assertEqual(
+            parse_first_entry(output_false).get("journal"), "Some Workshop Notes"
+        )
+        self.assertEqual(stats_false["converted"], 0)
+
+    def test_author_mismatch_does_not_apply_live_hit(self):
+        def mock_search(title, timeout=10, opener=None):
+            return [
+                _db_entry_lines(
+                    """@inproceedings{other,
+  title={A Completely Unique Live Lookup Title That Is Not In Any Dump},
+  author={Someone Else},
+  booktitle={Proceedings of ICML},
+  year={2021}
+}
+"""
+                )
+            ]
+
+        output, stats = run_normalize(
+            LIVE_WORKSHOP_INPUT,
+            {},
+            check_authors=True,
+            live_lookup=True,
+            dblp_search=mock_search,
+        )
+        entry = parse_first_entry(output)
+        self.assertEqual(entry.get("journal"), "Some Workshop Notes")
+        self.assertNotIn("booktitle", entry)
+        self.assertEqual(stats["converted"], 0)
+        selected = select_dblp_hit(
+            {"title": LIVE_UNIQUE_TITLE, "author": "Ada Lovelace"},
+            mock_search(LIVE_UNIQUE_TITLE),
+            check_authors=True,
+        )
+        self.assertIsNone(selected)
+
+    def test_local_hit_skips_live_search(self):
+        calls = []
+
+        def spy(title, timeout=10, opener=None):
+            calls.append(title)
+            return [live_official_lines()]
+
+        output, stats = run_normalize(
+            SHARED_AUTHOR_DEEP_LEARNING,
+            deep_learning_db(),
+            live_lookup=True,
+            dblp_search=spy,
+            check_authors=True,
+        )
+        self.assertEqual(calls, [])
+        entry = parse_first_entry(output)
+        self.assertEqual(entry["ID"], "mydeeplearning")
+        self.assertIn("booktitle", entry)
+        self.assertEqual(stats["converted"], 1)
+
+    def test_cli_live_lookup_flag_default_off(self):
+        parser = build_parser()
+        args = parser.parse_args(["-i", "a.bib"])
+        self.assertFalse(args.live_lookup)
+        args = parser.parse_args(["-i", "a.bib", "--live-lookup"])
+        self.assertTrue(args.live_lookup)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Opt-in `--live-lookup` so a local-index miss can do one DBLP title search (`h=5`). A hit is applied only with the same title-key + author-overlap rule as local matches. The user's cite key is kept. If a preprint is upgraded to a published record that lacks `eprint`, the input arXiv/`eprint` (and `archivePrefix=arXiv` when missing) is copied onto the official entry.

Timeouts, HTTP errors, and no-hit results keep the original entry and do not crash. Default CLI remains local-only (no network).

## Stack

Rebased onto current `main` after:
- #73 matching-harden
- #74 `--report` (merged)
- #75 `--used-in` (merged; CI green on 3.9 + 3.12)

## Behavior

- `normalize_bib(..., live_lookup=False, dblp_search=None)`: after a local DB miss, if `live_lookup` is true, call `dblp_search or search_dblp_by_title` with the original title, then `select_dblp_hit` / `preserve_eprint` / `replace_citation_key`. Change-report reason is `converted_live`.
- If `live_lookup` is false, `dblp_search` is never invoked even when a callable is passed.
- Injectable `opener` / `dblp_search` (urllib only; no new deps).

## Tests

`tests/test_normalize.py` drives the shipped helpers (mocked `dblp_search` / opener). No live DBLP call is required.

Local: `pytest tests -q --tb=short` → **89 passed, 16 subtests passed**.