### PR TITLE
Add PyPI trusted publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,66 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pypi-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/rebiber
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install package and test extras
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest tests -q --tb=short
+
+      - name: Build
+        run: uv build
+
+      - name: Verify wheel includes venue data
+        run: |
+          python - <<'PY'
+          import glob
+          import sys
+          import zipfile
+
+          wheels = glob.glob("dist/*.whl")
+          if not wheels:
+              sys.exit("no wheel in dist/")
+          with zipfile.ZipFile(wheels[0]) as zf:
+              names = set(zf.namelist())
+          jsons = [
+              n
+              for n in names
+              if n.startswith("rebiber/data/") and n.endswith(".json")
+          ]
+          has_list = "rebiber/bib_list.txt" in names
+          print(f"wheel={wheels[0]} json={len(jsons)} bib_list={has_list}")
+          if len(jsons) < 50 or not has_list:
+              sys.exit("refusing to publish a data-less wheel")
+          PY
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
PyPI is still on **1.1.3** while `main` is **1.3.0** (current tip includes #70–#76). There is no local `~/.pypirc` / `PYPI_TOKEN` / `UV_PUBLISH_TOKEN`, and the repo has no PyPI secret, so this PR adds [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) instead of uploading from a laptop.

### What this does
- New workflow: `.github/workflows/publish.yml`
- Triggers: `release` (`published`) and `workflow_dispatch`
- Uses the GitHub environment **`pypi`** (already created) + `id-token: write`
- Builds with `uv build`, runs `pytest`, and **refuses to upload** a wheel missing `rebiber/data/*.json` or `rebiber/bib_list.txt`
- Publishes via [`pypa/gh-action-pypi-publish@release/v1`](https://github.com/pypa/gh-action-pypi-publish)

Local `uv build` of current `main` already produced a data-full wheel:
- `dist/rebiber-1.3.0-py3-none-any.whl` (~49MB)
- 483 JSON files under `rebiber/data/` + `rebiber/bib_list.txt` + `rebiber/abbr.tsv`
- tests: 89 passed

### Human step (required before upload)
Add this repo as a trusted publisher on the existing project:

1. Open https://pypi.org/manage/project/rebiber/settings/publishing/
2. GitHub publisher:
   - **Owner:** `yuchenlin`
   - **Repository:** `rebiber`
   - **Workflow name:** `publish.yml`
   - **Environment name:** `pypi`
3. Merge this PR.
4. Publish **1.3.0 from current `main`** with **Actions → Publish to PyPI → Run workflow** (`workflow_dispatch` on `main`).

Do **not** republish from the existing GitHub Release **v1.3.0** — that tag is `006392e` (older than today’s `main`, missing #72–#76). Do **not** delete/move the `v1.3.0` tag. 1.3.0 is unused on PyPI, so uploading current `main` as 1.3.0 is the intended path.

After a successful run, `pip install -U rebiber` should get 1.3.0 with today’s code+data.