### PR TITLE
Add a year-to-date star history chart

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -30,19 +30,19 @@ jobs:
           enable-cache: true
           python-version: "3.12"
 
-      - name: Render star-history SVG
+      - name: Render star-history SVGs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: uv run --no-project python scripts/star_history.py --output docs/star-history.svg
+        run: uv run --no-project python scripts/star_history.py
 
-      - name: Commit chart if it changed
+      - name: Commit charts if they changed
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/star-history.svg
+          git add docs/star-history.svg docs/star-history-ytd.svg
           if git diff --staged --quiet; then
             echo "Star history unchanged"
           else
-            git commit -m "chore: refresh in-repo star history chart"
+            git commit -m "chore: refresh in-repo star history charts"
             git push
           fi

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Apart from handling outdated arXiv citations, __Rebiber__ also normalizes citati
 
 ## Changelog
 
-- **2026.08** In-repo star-history chart (`docs/star-history.svg`), refreshed weekly from the GitHub API. No star-history.com token.
+- **2026.08** In-repo star-history charts (all-time + YTD), refreshed weekly from the GitHub API. No star-history.com token.
 
 - **2026.08** Develop and CI with **uv** (`uv sync --extra dev`, `uv run pytest`, `uv build`). `pip install -e .` remains supported.
 
@@ -294,9 +294,15 @@ Alternatively, you can still download bib files from DBLP by hand into `raw_data
 
 ## Star History
 
-Chart generated in this repo from the GitHub stargazers API (no third-party host). A weekly Action refreshes [`docs/star-history.svg`](docs/star-history.svg).
+Charts generated in this repo from the GitHub stargazers API (no third-party host). A weekly Action refreshes [`docs/star-history.svg`](docs/star-history.svg) and [`docs/star-history-ytd.svg`](docs/star-history-ytd.svg).
+
+**All time**
 
 ![Rebiber star history](docs/star-history.svg)
+
+**Year to date**
+
+![Rebiber star history YTD](docs/star-history-ytd.svg)
 
 ## Contact
 

--- a/docs/star-history-ytd.svg
+++ b/docs/star-history-ytd.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="420" viewBox="0 0 880 420" role="img" aria-label="yuchenlin/rebiber stars (2026 YTD)">
+  <rect width="100%" height="100%" fill="#ffffff"/>
+  <text x="64" y="24" font-size="16" font-weight="600" fill="#111827" font-family="ui-sans-serif, system-ui, sans-serif">yuchenlin/rebiber stars (2026 YTD)</text>
+  <text x="64" y="40" font-size="12" fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">3,026 stars · +77 in 2026 · updated 2026-08-10</text>
+  <line x1="64.0" y1="364.0" x2="856.0" y2="364.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="64.0" y1="300.8" x2="856.0" y2="300.8" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="64.0" y1="237.6" x2="856.0" y2="237.6" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="64.0" y1="174.4" x2="856.0" y2="174.4" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="64.0" y1="111.2" x2="856.0" y2="111.2" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="64.0" y1="48.0" x2="856.0" y2="48.0" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="64.0" y1="48.0" x2="64.0" y2="364.0" stroke="#f3f4f6" stroke-width="1"/>
+  <line x1="175.1" y1="48.0" x2="175.1" y2="364.0" stroke="#f3f4f6" stroke-width="1"/>
+  <line x1="275.4" y1="48.0" x2="275.4" y2="364.0" stroke="#f3f4f6" stroke-width="1"/>
+  <line x1="386.5" y1="48.0" x2="386.5" y2="364.0" stroke="#f3f4f6" stroke-width="1"/>
+  <line x1="494.0" y1="48.0" x2="494.0" y2="364.0" stroke="#f3f4f6" stroke-width="1"/>
+  <line x1="605.1" y1="48.0" x2="605.1" y2="364.0" stroke="#f3f4f6" stroke-width="1"/>
+  <line x1="712.7" y1="48.0" x2="712.7" y2="364.0" stroke="#f3f4f6" stroke-width="1"/>
+  <line x1="823.7" y1="48.0" x2="823.7" y2="364.0" stroke="#f3f4f6" stroke-width="1"/>
+  <path d="M 64.0,364.0 L 64.0,335.6 67.6,332.4 78.3,329.2 81.9,319.8 85.5,310.3 92.7,307.1 99.8,304.0 107.0,300.8 114.2,297.6 157.2,285.0 160.8,275.5 164.3,272.4 171.5,269.2 175.1,262.9 189.4,259.7 193.0,256.6 196.6,253.4 203.8,250.2 228.9,247.1 257.5,243.9 264.7,240.8 293.4,234.4 300.5,231.3 307.7,228.1 329.2,225.0 357.9,218.6 368.6,215.5 383.0,212.3 390.1,209.2 400.9,206.0 404.5,202.8 411.6,199.7 451.0,196.5 454.6,193.4 458.2,190.2 472.5,187.0 486.9,183.9 497.6,180.7 504.8,174.4 512.0,171.2 515.5,168.1 540.6,164.9 544.2,161.8 580.1,155.4 601.6,152.3 608.7,149.1 615.9,146.0 619.5,142.8 669.6,139.6 680.4,136.5 687.6,133.3 694.7,130.2 719.8,127.0 723.4,123.8 755.7,120.7 759.2,117.5 791.5,111.2 802.2,108.0 809.4,104.9 827.3,101.7 845.2,98.6 852.4,92.2 856.0,92.2 L 856.0,364.0 Z" fill="#dbeafe"/>
+  <polyline fill="none" stroke="#2563eb" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round" points="64.0,335.6 67.6,332.4 78.3,329.2 81.9,319.8 85.5,310.3 92.7,307.1 99.8,304.0 107.0,300.8 114.2,297.6 157.2,285.0 160.8,275.5 164.3,272.4 171.5,269.2 175.1,262.9 189.4,259.7 193.0,256.6 196.6,253.4 203.8,250.2 228.9,247.1 257.5,243.9 264.7,240.8 293.4,234.4 300.5,231.3 307.7,228.1 329.2,225.0 357.9,218.6 368.6,215.5 383.0,212.3 390.1,209.2 400.9,206.0 404.5,202.8 411.6,199.7 451.0,196.5 454.6,193.4 458.2,190.2 472.5,187.0 486.9,183.9 497.6,180.7 504.8,174.4 512.0,171.2 515.5,168.1 540.6,164.9 544.2,161.8 580.1,155.4 601.6,152.3 608.7,149.1 615.9,146.0 619.5,142.8 669.6,139.6 680.4,136.5 687.6,133.3 694.7,130.2 719.8,127.0 723.4,123.8 755.7,120.7 759.2,117.5 791.5,111.2 802.2,108.0 809.4,104.9 827.3,101.7 845.2,98.6 852.4,92.2 856.0,92.2"/>
+  <text x="56.0" y="368.0" text-anchor="end" font-size="12" fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">2,940</text>
+  <text x="56.0" y="304.8" text-anchor="end" font-size="12" fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">2,960</text>
+  <text x="56.0" y="241.6" text-anchor="end" font-size="12" fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">2,980</text>
+  <text x="56.0" y="178.4" text-anchor="end" font-size="12" fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">3,000</text>
+  <text x="56.0" y="115.2" text-anchor="end" font-size="12" fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">3,020</text>
+  <text x="56.0" y="52.0" text-anchor="end" font-size="12" fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">3,040</text>
+  <text x="64.0" y="384.0" text-anchor="middle" font-size="12" fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">Jan 2026</text>
+  <text x="175.1" y="384.0" text-anchor="middle" font-size="12" fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">Feb</text>
+  <text x="275.4" y="384.0" text-anchor="middle" font-size="12" fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">Mar</text>
+  <text x="386.5" y="384.0" text-anchor="middle" font-size="12" fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">Apr</text>
+  <text x="494.0" y="384.0" text-anchor="middle" font-size="12" fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">May</text>
+  <text x="605.1" y="384.0" text-anchor="middle" font-size="12" fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">Jun</text>
+  <text x="712.7" y="384.0" text-anchor="middle" font-size="12" fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">Jul</text>
+  <text x="823.7" y="384.0" text-anchor="middle" font-size="12" fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">Aug</text>
+  <line x1="64" y1="364" x2="856" y2="364" stroke="#9ca3af" stroke-width="1"/>
+  <line x1="64" y1="48" x2="64" y2="364" stroke="#9ca3af" stroke-width="1"/>
+</svg>

--- a/scripts/star_history.py
+++ b/scripts/star_history.py
@@ -27,6 +27,7 @@ import urllib.request
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.dirname(SCRIPT_DIR)
 DEFAULT_OUTPUT = os.path.join(REPO_ROOT, "docs", "star-history.svg")
+DEFAULT_OUTPUT_YTD = os.path.join(REPO_ROOT, "docs", "star-history-ytd.svg")
 USER_AGENT = "rebiber-star-history (+https://github.com/yuchenlin/rebiber)"
 API_VERSION = "2022-11-28"
 LINK_NEXT_RE = re.compile(r'<([^>]+)>;\s*rel="next"')
@@ -60,6 +61,68 @@ def cumulative_daily(starred_at_values):
         total += counts[day]
         series.append((day, total))
     return series
+
+
+def ytd_series(series, year, today=None):
+    """Zoom a cumulative series to calendar ``year`` (absolute totals).
+
+    Starts at 1 Jan (carrying forward the prior-year total) and extends to
+    ``today`` so a quiet end of year still fills the axis. Returns
+    ``(points, gained_this_year)``.
+    """
+    if today is None:
+        today = datetime.date.today()
+    start = datetime.date(int(year), 1, 1)
+    if today < start:
+        return [], 0
+    baseline = 0
+    year_points = []
+    for day, count in series:
+        if day < start:
+            baseline = count
+        elif day <= today:
+            year_points.append((day, count))
+    points = []
+    if not year_points or year_points[0][0] > start:
+        points.append((start, baseline))
+    points.extend(year_points)
+    if points[-1][0] < today:
+        points.append((today, points[-1][1]))
+    gained = points[-1][1] - baseline
+    return points, gained
+
+
+def _x_tick_dates(first_day, last_day):
+    """Year ticks for multi-year spans; month ticks for a YTD-sized window."""
+    span_days = max((last_day - first_day).days, 1)
+    ticks = []
+    if span_days > 400:
+        year = first_day.year
+        while year <= last_day.year:
+            mark = datetime.date(year, 1, 1)
+            if mark < first_day:
+                mark = first_day
+            ticks.append(mark)
+            year += 1
+        label = lambda day: day.strftime("%Y")
+    else:
+        year, month = first_day.year, first_day.month
+        ticks.append(first_day)
+        while True:
+            month += 1
+            if month > 12:
+                month = 1
+                year += 1
+            mark = datetime.date(year, month, 1)
+            if mark > last_day:
+                break
+            ticks.append(mark)
+        label = lambda day: (
+            day.strftime("%b") if day.month != 1 else day.strftime("%b %Y")
+        )
+    if ticks[-1] != last_day and (last_day - ticks[-1]).days > 20:
+        ticks.append(last_day)
+    return ticks, label
 
 
 def downsample(series, max_points=400):
@@ -98,25 +161,40 @@ def _nice_ticks(lo, hi, target=5):
     return ticks
 
 
-def render_svg(series, repo, generated_on, width=880, height=420):
+def render_svg(
+    series,
+    repo,
+    generated_on,
+    width=880,
+    height=420,
+    title=None,
+    subtitle=None,
+    y_min=0,
+):
     """Render a simple line chart. ``series`` is ``[(date, count), ...]``."""
     if not series:
         raise ValueError("no star events to plot")
     pad_l, pad_r, pad_t, pad_b = 64, 24, 48, 56
     plot_w = width - pad_l - pad_r
     plot_h = height - pad_t - pad_b
-    first_day, _first_count = series[0]
+    first_day, first_count = series[0]
     last_day, last_count = series[-1]
     span_days = max((last_day - first_day).days, 1)
-    y_max = max(last_count, 1)
-    y_ticks = _nice_ticks(0, y_max, target=5)
+    y_lo = int(y_min)
+    y_max = max(last_count, first_count, y_lo + 1)
+    y_ticks = _nice_ticks(y_lo, y_max, target=5)
     chart_top = y_ticks[-1] if y_ticks else y_max
+    chart_bot = y_ticks[0] if y_ticks else y_lo
+    if chart_top <= chart_bot:
+        chart_top = chart_bot + 1
 
     def x_of(day):
         return pad_l + plot_w * ((day - first_day).days / float(span_days))
 
     def y_of(count):
-        return pad_t + plot_h * (1.0 - (count / float(chart_top)))
+        return pad_t + plot_h * (
+            1.0 - ((count - chart_bot) / float(chart_top - chart_bot))
+        )
 
     points = downsample(series)
     coords = [(x_of(day), y_of(count)) for day, count in points]
@@ -129,17 +207,7 @@ def render_svg(series, repo, generated_on, width=880, height=420):
         pad_t + plot_h,
     )
 
-    # Year ticks on X.
-    year_ticks = []
-    year = first_day.year
-    while year <= last_day.year:
-        mark = datetime.date(year, 1, 1)
-        if mark < first_day:
-            mark = first_day
-        year_ticks.append(mark)
-        year += 1
-    if year_ticks[-1] != last_day:
-        year_ticks.append(last_day)
+    x_ticks, x_label = _x_tick_dates(first_day, last_day)
 
     grid = []
     labels = []
@@ -154,7 +222,7 @@ def render_svg(series, repo, generated_on, width=880, height=420):
             'fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">'
             "%s</text>" % (pad_l - 8, y + 4, "{:,}".format(tick))
         )
-    for mark in year_ticks:
+    for mark in x_ticks:
         x = x_of(mark)
         grid.append(
             '<line x1="%.1f" y1="%.1f" x2="%.1f" y2="%.1f" '
@@ -164,11 +232,15 @@ def render_svg(series, repo, generated_on, width=880, height=420):
         labels.append(
             '<text x="%.1f" y="%.1f" text-anchor="middle" font-size="12" '
             'fill="#6b7280" font-family="ui-sans-serif, system-ui, sans-serif">'
-            "%s</text>" % (x, pad_t + plot_h + 20, mark.strftime("%Y"))
+            "%s</text>" % (x, pad_t + plot_h + 20, x_label(mark))
         )
 
-    title = "%s star history" % repo
-    subtitle = "{:,} stars · updated {}".format(last_count, generated_on.isoformat())
+    if title is None:
+        title = "%s star history" % repo
+    if subtitle is None:
+        subtitle = "{:,} stars · updated {}".format(
+            last_count, generated_on.isoformat()
+        )
     svg = """\
 <svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}" role="img" aria-label="{title}">
   <rect width="100%" height="100%" fill="#ffffff"/>
@@ -257,11 +329,24 @@ def build_parser():
     parser.add_argument("--repo", default="rebiber")
     parser.add_argument("--output", default=DEFAULT_OUTPUT)
     parser.add_argument(
+        "--output-ytd",
+        default=DEFAULT_OUTPUT_YTD,
+        help="Year-to-date chart path (empty string to skip).",
+    )
+    parser.add_argument(
         "--token",
         default=os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or "",
         help="GitHub token (default: GITHUB_TOKEN or GH_TOKEN).",
     )
     return parser
+
+
+def _write_svg(path, svg):
+    out_dir = os.path.dirname(os.path.abspath(path))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(path, "w", encoding="utf8") as handle:
+        handle.write(svg)
 
 
 def main(argv=None):
@@ -271,20 +356,34 @@ def main(argv=None):
     if not series:
         print("No stargazer timestamps returned.", file=sys.stderr)
         return 1
-    svg = render_svg(
-        series,
-        repo="%s/%s" % (args.owner, args.repo),
-        generated_on=datetime.date.today(),
-    )
-    out_dir = os.path.dirname(os.path.abspath(args.output))
-    if out_dir:
-        os.makedirs(out_dir, exist_ok=True)
-    with open(args.output, "w", encoding="utf8") as handle:
-        handle.write(svg)
+    today = datetime.date.today()
+    repo = "%s/%s" % (args.owner, args.repo)
+    svg = render_svg(series, repo=repo, generated_on=today)
+    _write_svg(args.output, svg)
     print(
         "Wrote %s (%s stars, %s events)"
         % (args.output, series[-1][1], len(starred))
     )
+    if args.output_ytd:
+        ytd_points, gained = ytd_series(series, today.year, today=today)
+        if not ytd_points:
+            print("No YTD points to plot.", file=sys.stderr)
+            return 1
+        ytd_svg = render_svg(
+            ytd_points,
+            repo=repo,
+            generated_on=today,
+            title="%s stars (%s YTD)" % (repo, today.year),
+            subtitle="{:,} stars · {:+,} in {} · updated {}".format(
+                ytd_points[-1][1], gained, today.year, today.isoformat()
+            ),
+            y_min=ytd_points[0][1],
+        )
+        _write_svg(args.output_ytd, ytd_svg)
+        print(
+            "Wrote %s (%s YTD, %+d this year)"
+            % (args.output_ytd, today.year, gained)
+        )
     return 0
 
 

--- a/tests/test_star_history.py
+++ b/tests/test_star_history.py
@@ -44,6 +44,40 @@ def test_downsample_keeps_ends():
     assert len(out) <= 5
 
 
+def test_ytd_series_carries_baseline_and_counts_gain():
+    series = [
+        (datetime.date(2025, 12, 31), 100),
+        (datetime.date(2026, 1, 2), 103),
+        (datetime.date(2026, 3, 1), 110),
+    ]
+    points, gained = star_history.ytd_series(
+        series, 2026, today=datetime.date(2026, 8, 10)
+    )
+    assert points[0] == (datetime.date(2026, 1, 1), 100)
+    assert (datetime.date(2026, 1, 2), 103) in points
+    assert points[-1] == (datetime.date(2026, 8, 10), 110)
+    assert gained == 10
+
+
+def test_ytd_series_empty_before_year_starts_at_zero():
+    series = [(datetime.date(2026, 2, 1), 4)]
+    points, gained = star_history.ytd_series(
+        series, 2026, today=datetime.date(2026, 2, 1)
+    )
+    assert points[0] == (datetime.date(2026, 1, 1), 0)
+    assert points[-1] == (datetime.date(2026, 2, 1), 4)
+    assert gained == 4
+
+
+def test_x_ticks_use_months_for_short_spans():
+    ticks, label = star_history._x_tick_dates(
+        datetime.date(2026, 1, 1), datetime.date(2026, 8, 10)
+    )
+    assert ticks[0] == datetime.date(2026, 1, 1)
+    assert datetime.date(2026, 6, 1) in ticks
+    assert label(datetime.date(2026, 6, 1)) == "Jun"
+
+
 def test_render_svg_contains_title_and_total():
     series = [
         (datetime.date(2021, 1, 25), 1),


### PR DESCRIPTION
Adds a second in-repo chart for calendar-year star growth.

- `docs/star-history-ytd.svg`: X-axis Jan→today, Y-axis starts at the Jan 1 total so this year's +N is visible
- Subtitle currently **3,026 stars · +77 in 2026**
- Weekly Action refreshes both SVGs
- Tests cover YTD baseline/gain and month ticks

Still no third-party host.