### PR TITLE
Remove the old USC contact email from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,4 +307,3 @@ Charts generated in this repo from the GitHub stargazers API (no third-party hos
 ## Contact
 
 Please email [billyuchenlin@gmail.com](mailto:billyuchenlin@gmail.com) or [i@yuchenlin.xyz](mailto:i@yuchenlin.xyz), or open a [GitHub issue](https://github.com/yuchenlin/rebiber/issues) if you have any questions or suggestions.
-(USC: yuchen.lin@usc.edu)


### PR DESCRIPTION
Drop the old `yuchen.lin@usc.edu` line from Contact. Remaining addresses are Gmail and `i@yuchenlin.xyz`.