### PR TITLE
Use git+https for the uv tool install from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Rebiber is developed and CI-tested with [uv](https://docs.astral.sh/uv/). `pip` 
 
 ```bash
 # one-off CLI from GitHub (latest dumps + bug fixes)
-uv tool install https://github.com/yuchenlin/rebiber
+uv tool install git+https://github.com/yuchenlin/rebiber
 
 # develop from a checkout
 git clone https://github.com/yuchenlin/rebiber.git


### PR DESCRIPTION
Takes the useful bit of #79 into the current uv install section.

`uv tool install git+https://github.com/yuchenlin/rebiber` is the PEP 508 git source form. The old PR cannot merge: it conflicts with the #80 README rewrite.