### PR TITLE
Open PRs from dump and chart bots instead of pushing main

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -10,9 +10,6 @@ on:
       - scripts/star_history.py
       - .github/workflows/star-history.yml
 
-permissions:
-  contents: write
-
 concurrency:
   group: star-history
   cancel-in-progress: true
@@ -21,6 +18,9 @@ jobs:
   render:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -35,14 +35,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uv run --no-project python scripts/star_history.py
 
-      - name: Commit charts if they changed
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/star-history.svg docs/star-history-ytd.svg
-          if git diff --staged --quiet; then
-            echo "Star history unchanged"
-          else
-            git commit -m "chore: refresh in-repo star history charts"
-            git push
-          fi
+      - name: Test star history charts
+        run: uv run --no-project --with pytest python -m pytest tests/test_star_history.py -q
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: refresh in-repo star history charts"
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          branch: chore/update-star-history
+          delete-branch: true
+          title: "chore: refresh star history charts"
+          body: |
+            Automated refresh of the in-repo star history SVGs.
+
+            Opened by `.github/workflows/star-history.yml` instead of pushing to `main`.
+          add-paths: |
+            docs/star-history.svg
+            docs/star-history-ytd.svg

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pytest:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-conferences.yml
+++ b/.github/workflows/update-conferences.yml
@@ -5,13 +5,13 @@ on:
     - cron: "0 3 1 * *" # first day of every month at 03:00 UTC
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
   update-conferences:
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -25,22 +25,28 @@ jobs:
       - name: Install package
         run: uv sync --frozen
 
+      # Fail-soft: a DBLP miss should not skip leftover conversion, ACL, or the PR.
       - name: Download recent conference data from DBLP
+        continue-on-error: true
         run: |
           mkdir -p rebiber/raw_data
           YEAR=$(date +%Y)
           PREV=$((YEAR - 1))
           PAST_END=$((YEAR - 2))
+          status=0
           # Older years: skip-existing (re-fetch only if the dump looks incomplete).
           if [[ "$PAST_END" -ge 2024 ]]; then
-            uv run python -m rebiber.download_dblp --start-year 2024 --end-year "$PAST_END"
+            uv run python -m rebiber.download_dblp --start-year 2024 --end-year "$PAST_END" || status=1
           fi
           # Current and previous year: re-fetch so late-added papers are picked up.
-          uv run python -m rebiber.download_dblp --start-year "$PREV" --end-year "$YEAR" --force
+          uv run python -m rebiber.download_dblp --start-year "$PREV" --end-year "$YEAR" --force || status=1
+          exit "$status"
 
       - name: Convert leftover bib files
+        continue-on-error: true
         run: |
           shopt -s nullglob
+          status=0
           for bibfile in rebiber/raw_data/*.bib; do
             base=$(basename "$bibfile" .bib)
             # anthology.bib is handled in the ACL step
@@ -51,14 +57,20 @@ jobs:
             entry="data/${base}.bib.json"
             if [[ ! -f "$jsonfile" ]]; then
               echo "Converting $bibfile -> $jsonfile"
-              uv run python -m rebiber.bib2json -i "$bibfile" -o "$jsonfile"
-              if ! grep -qxF "$entry" rebiber/bib_list.txt; then
-                echo "$entry" >> rebiber/bib_list.txt
+              if uv run python -m rebiber.bib2json -i "$bibfile" -o "$jsonfile"; then
+                if ! grep -qxF "$entry" rebiber/bib_list.txt; then
+                  echo "$entry" >> rebiber/bib_list.txt
+                fi
+              else
+                echo "Failed to convert $bibfile"
+                status=1
               fi
             fi
           done
+          exit "$status"
 
       - name: Update ACL Anthology data
+        continue-on-error: true
         run: |
           mkdir -p rebiber/raw_data
           echo "Downloading ACL Anthology bib file..."
@@ -69,14 +81,19 @@ jobs:
           echo "Splitting acl.json and refreshing bib_list.txt..."
           uv run python scripts/refresh_bib_list.py --split-acl --chunk-size 50000
 
-      - name: Commit and push changes
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add rebiber/data/ rebiber/bib_list.txt
-          if git diff --staged --quiet; then
-            echo "No new conference data found"
-          else
-            git commit -m "chore: update conference data from DBLP and ACL Anthology"
-            git push
-          fi
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: update conference data from DBLP and ACL Anthology"
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          branch: chore/update-conference-data
+          delete-branch: true
+          title: "chore: update conference data"
+          body: |
+            Automated monthly refresh of conference dumps from DBLP and the ACL Anthology.
+
+            Opened by `.github/workflows/update-conferences.yml` instead of pushing to `main`.
+          add-paths: |
+            rebiber/data/
+            rebiber/bib_list.txt


### PR DESCRIPTION
## Summary
- Conference-data and star-history bots no longer `git push` to `main`. They open a PR via `peter-evans/create-pull-request@v6` (`contents: write` + `pull-requests: write` on those jobs only).
- Download/convert/ACL steps are fail-soft (`continue-on-error`) so a single DBLP or Anthology miss still produces a PR if any files changed.
- Star-history runs `uv run --no-project --with pytest python -m pytest tests/test_star_history.py -q` before opening the chart PR.
- `tests.yml` is now `permissions: contents: read`.

## Test plan
- [x] Workflow YAML only; no Python changes.
- [ ] Tests CI green on this PR.
- [ ] Confirm neither bot workflow still contains `git push`.