### PR TITLE
Harden bib2json loader: braces, month fields, NFKD, BOM

### DIFF
--- a/rebiber/bib2json.py
+++ b/rebiber/bib2json.py
@@ -15,10 +15,12 @@ _SKIP_ENTRY_PREFIXES = ("@string", "@comment", "@preamble")
 def normalize_title(title_str, keep_digits=False):
     """Normalize a title to a lowercase key.
 
-    Combining marks are dropped, then non-letter characters are stripped.
+    Apply NFKD first so precomposed characters decompose (é → e + accent),
+    then drop combining marks and strip non-letter characters.
     By default only ASCII letters are kept (compatible with existing dumps).
     Pass ``keep_digits=True`` to also keep ASCII digits (new dumps).
     """
+    title_str = unicodedata.normalize("NFKD", title_str)
     title_str = "".join(ch for ch in title_str if not unicodedata.combining(ch))
     if keep_digits:
         title_str = re.sub(r"[^a-zA-Z0-9]", r"", title_str)
@@ -39,9 +41,22 @@ def _is_skip_entry(stripped_lower):
     return any(stripped_lower.startswith(prefix) for prefix in _SKIP_ENTRY_PREFIXES)
 
 
+def _is_month_field_line(line):
+    """True only for a month= field assignment, not a whole @ entry."""
+    stripped = line.lstrip()
+    if stripped.startswith("@"):
+        return False
+    return re.match(r"month\s*=", stripped, flags=re.IGNORECASE) is not None
+
+
+def _flush_entry(all_bib_entries, bib_entry_buffer):
+    if bib_entry_buffer and bib_entry_buffer not in (["\n"], [""]):
+        all_bib_entries.append(bib_entry_buffer)
+
+
 def load_bib_file(bibpath):
     all_bib_entries = []
-    with open(bibpath, encoding="utf8") as f:
+    with open(bibpath, encoding="utf-8-sig") as f:
         bib_entry_buffer = []
         lines = f.readlines() + ["\n"]
 
@@ -63,21 +78,48 @@ def load_bib_file(bibpath):
                     skip_brace_count = None
                 continue
 
+            # A line starting with @ starts a new entry (or a skip block).
+            # If an unclosed leftover buffer exists, split there.
+            if stripped.startswith("@"):
+                if bib_entry_buffer:
+                    print(
+                        "WARNING: unclosed braces before next @ in %s; "
+                        "splitting leftover buffer." % bibpath
+                    )
+                    _flush_entry(all_bib_entries, bib_entry_buffer)
+                    bib_entry_buffer = []
+                    brace_count = 0
+                if _is_skip_entry(stripped_lower):
+                    skip_brace_count = line.count("{") - line.count("}")
+                    if skip_brace_count <= 0:
+                        skip_brace_count = None
+                    continue
+                bib_entry_buffer = [line]
+                brace_count = line.count("{") - line.count("}")
+                if brace_count <= 0:
+                    _flush_entry(all_bib_entries, bib_entry_buffer)
+                    bib_entry_buffer = []
+                    brace_count = 0
+                continue
+
             if _is_skip_entry(stripped_lower):
                 skip_brace_count = line.count("{") - line.count("}")
                 if skip_brace_count <= 0:
                     skip_brace_count = None
                 continue
 
+            # Leading / between-entry junk: do not start a buffer.
+            if not bib_entry_buffer:
+                continue
+
             bib_entry_buffer.append(line)
             brace_count += line.count("{") - line.count("}")
 
-            # If brace_count is zero, then all opened braces have been closed
-            if brace_count == 0:
-                # Filter out the entries that only contain ['\n'] or ['']
-                if bib_entry_buffer != ["\n"] and bib_entry_buffer != [""]:
-                    all_bib_entries.append(bib_entry_buffer)
+            # End-of-entry when brace_count <= 0; reset to recover from extra }.
+            if brace_count <= 0:
+                _flush_entry(all_bib_entries, bib_entry_buffer)
                 bib_entry_buffer = []
+                brace_count = 0
 
     if bib_entry_buffer and bib_entry_buffer not in (["\n"], [""]):
         print(
@@ -93,18 +135,23 @@ def build_json(all_bib_entries):
     all_bib_dict = {}
     num_exceptions = 0
     for bib_entry in tqdm(all_bib_entries[:]):
+        # Filter month= field lines only; never drop a whole @... line.
         bib_entry_str = " ".join(
-            [
-                line
-                for line in bib_entry
-                if not re.search(r"month\s*=", line, flags=re.IGNORECASE)
-            ]
-        ).lower()
+            line for line in bib_entry if not _is_month_field_line(line)
+        )
         try:
-            bib_entry_parsed = bibtexparser.loads(bib_entry_str)
+            bibparser = bibtexparser.bparser.BibTexParser(
+                ignore_nonstandard_types=False
+            )
+            bib_entry_parsed = bibtexparser.loads(bib_entry_str, bibparser)
             bib_key = normalize_title(
                 bib_entry_parsed.entries[0]["title"], keep_digits=True
             )
+            if bib_key in all_bib_dict:
+                print(
+                    "WARNING: duplicate normalize_title key %r; keeping last."
+                    % bib_key
+                )
             all_bib_dict[bib_key] = bib_entry
         except Exception as e:
             print(bib_entry)

--- a/tests/test_bib2json.py
+++ b/tests/test_bib2json.py
@@ -252,3 +252,149 @@ def test_load_bib_file_keeps_unclosed_entry():
         assert "broken" in joined
     finally:
         os.unlink(path)
+
+
+def test_load_bib_file_recovers_from_extra_closing_brace():
+    path = _write_bib(
+        """
+@article{one,
+  title={First Title},
+  year={2020}
+}}
+@article{two,
+  title={Second Title},
+  year={2021}
+}
+"""
+    )
+    try:
+        entries = load_bib_file(path)
+        assert len(entries) == 2
+        first = "".join(entries[0])
+        second = "".join(entries[1])
+        assert "First Title" in first
+        assert "Second Title" in second
+        assert "Second Title" not in first
+        assert "@article" in second.lower()
+    finally:
+        os.unlink(path)
+
+
+def test_load_bib_file_splits_unclosed_buffer_at_next_at():
+    path = _write_bib(
+        """@article{broken,
+  title={Unclosed Title},
+  author={Alice}
+
+@article{two,
+  title={Second Title},
+  year={2021}
+}
+"""
+    )
+    try:
+        entries = load_bib_file(path)
+        assert len(entries) == 2
+        first = "".join(entries[0])
+        second = "".join(entries[1])
+        assert "Unclosed Title" in first
+        assert "Second Title" in second
+        assert "Second Title" not in first
+        assert "@article" in second.lower()
+    finally:
+        os.unlink(path)
+
+
+def test_build_json_keeps_single_line_entry_containing_month():
+    path = _write_bib(
+        "@article{x, title={Single Line Month}, month={jan}, year={2020}}\n"
+    )
+    try:
+        entries = load_bib_file(path)
+        assert len(entries) == 1
+        db = build_json(entries)
+        key = normalize_title("Single Line Month", keep_digits=True)
+        assert key == "singlelinemonth"
+        assert key in db
+        joined = "".join(db[key])
+        assert "Single Line Month" in joined
+        assert "month=" in joined.lower().replace(" ", "")
+    finally:
+        os.unlink(path)
+
+
+def test_normalize_title_nfkd_before_ascii_strip():
+    assert normalize_title("Café") == "cafe"
+    assert normalize_title("résumé") == "resume"
+    assert normalize_title("naïve") == "naive"
+    assert normalize_title("é") == "e"
+    assert normalize_title("e\u0301") == "e"
+    assert normalize_title("Café au lait 2", keep_digits=True) == "cafeaulait2"
+
+
+def test_load_bib_file_accepts_utf8_sig_bom():
+    handle = tempfile.NamedTemporaryFile("wb", suffix=".bib", delete=False)
+    try:
+        payload = (
+            "@article{bom,\n" "  title={BOM Title},\n" "  year={2020}\n" "}\n"
+        )
+        handle.write(b"\xef\xbb\xbf" + payload.encode("utf-8"))
+        handle.close()
+        entries = load_bib_file(handle.name)
+        assert len(entries) == 1
+        joined = "".join(entries[0])
+        assert "BOM Title" in joined
+        assert "\ufeff" not in joined
+        first_nonempty = next(line for line in entries[0] if line.strip())
+        assert first_nonempty.lstrip().startswith("@")
+    finally:
+        os.unlink(handle.name)
+
+
+def test_load_bib_file_ignores_leading_junk_before_at():
+    path = _write_bib(
+        """this is not an entry
+random junk
+@article{one,
+  title={Only Real},
+  year={2020}
+}
+"""
+    )
+    try:
+        entries = load_bib_file(path)
+        assert len(entries) == 1
+        joined = "".join(entries[0])
+        assert "Only Real" in joined
+        assert "random junk" not in joined
+        assert joined.lstrip().startswith("@")
+    finally:
+        os.unlink(path)
+
+
+def test_build_json_duplicate_key_warns_and_keeps_last(capsys):
+    path = _write_bib(
+        """
+@article{first,
+  title={Same Title},
+  year={2020}
+}
+@article{second,
+  title={Same Title},
+  year={2021}
+}
+"""
+    )
+    try:
+        entries = load_bib_file(path)
+        db = build_json(entries)
+        key = normalize_title("Same Title", keep_digits=True)
+        assert key == "sametitle"
+        assert key in db
+        assert db[key] == entries[1]
+        assert "2021" in "".join(db[key])
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.out
+        assert key in captured.out
+    finally:
+        os.unlink(path)


### PR DESCRIPTION
Harden the BibTeX loader so malformed files and encodings no longer glue or drop entries.

## Changes
- Start a new entry buffer only when a line starts with `@`; ignore leading junk.
- End an entry when `brace_count <= 0`, then reset to 0 so an extra `}` cannot swallow later entries.
- If an unclosed leftover buffer is still open when a later line starts with `@`, split there instead of gluing the rest of the file.
- `build_json` skips only `month=` **field** lines, never a whole single-line `@...` entry that happens to contain `month=`. Titles containing the word Month are kept.
- Parse with `BibTexParser(ignore_nonstandard_types=False)` and without lowercasing the whole blob.
- `normalize_title` applies NFKD before stripping non-ASCII so `é` → `e`.
- Load files with `encoding="utf-8-sig"` so a UTF-8 BOM is stripped.
- Duplicate `normalize_title` keys still last-wins for compatibility, but now print a WARNING.

## Tests
Covers extra `}`, leftover + next `@` split, single-line `month=` entries, NFKD, UTF-8 BOM, comment-inside-entry still kept, plus leading junk and duplicate-key warnings.

`uv run pytest tests -q` — 103 passed on Python 3.9 and 3.12.