### PR TITLE
Add opt-in --keep and --protect-titles camera-ready helpers

### DIFF
--- a/rebiber/camera.py
+++ b/rebiber/camera.py
@@ -1,0 +1,127 @@
+"""Camera-ready BibTeX helpers (pure functions; no I/O).
+
+These are opt-in post-processing steps for ``normalize_bib``. They do not
+change title matching, live DBLP lookup, or bib2json.
+"""
+
+import re
+
+
+# Token characters that may sit inside an acronym (GPT-2, C++, NLP/CL).
+_TOKEN_INNER = set("-+/")
+# Hyphen/slash at the end of a span are separators; '+' is part of C++.
+_TOKEN_TRAIL_STRIP = set("-/")
+
+# Leading backslash + letters is a LaTeX command; leave it untouched.
+_LATEX_CMD_RE = re.compile(r"\\[a-zA-Z]+")
+
+
+def _as_keep_names(keep_names):
+    """Normalize a keep-list from None / str / iterable to a list of names."""
+    if not keep_names:
+        return []
+    if isinstance(keep_names, str):
+        return [part.strip() for part in keep_names.split(",") if part.strip()]
+    return [str(name).strip() for name in keep_names if str(name).strip()]
+
+
+def _is_protectable_token(token):
+    """True for uppercase tokens / acronyms that BibTeX styles would smash.
+
+    Regular Title-Case words (``Deep``, ``Learning``) are left alone. Single
+    letters (``A``, ``I``) are not acronyms.
+    """
+    if not token:
+        return False
+    uppers = sum(1 for char in token if char.isupper())
+    if uppers >= 2:
+        return True
+    # CamelCase / internal capital: ResNet, PyTorch, iPhone.
+    if len(token) >= 2 and any(char.isupper() for char in token[1:]):
+        return True
+    # One capital plus a digit or plus: 3D, C++.
+    if uppers >= 1 and any(char.isdigit() or char == "+" for char in token):
+        return True
+    return False
+
+
+def protect_title_caps(title):
+    """Wrap uppercase tokens / acronyms in braces.
+
+    Does **not** wrap the entire title in one pair of braces (the usual
+    ``{{Whole Title}}`` anti-pattern). Tokens already inside ``{...}`` are
+    left unchanged so ``{BERT}`` is not turned into ``{{BERT}}``.
+    """
+    if title is None:
+        return ""
+    title = str(title)
+    if not title:
+        return title
+
+    out = []
+    i = 0
+    n = len(title)
+    depth = 0
+    while i < n:
+        char = title[i]
+        if char == "{":
+            depth += 1
+            out.append(char)
+            i += 1
+            continue
+        if char == "}":
+            if depth:
+                depth -= 1
+            out.append(char)
+            i += 1
+            continue
+        if depth > 0:
+            out.append(char)
+            i += 1
+            continue
+        if char == "\\":
+            match = _LATEX_CMD_RE.match(title, i)
+            if match:
+                out.append(match.group(0))
+                i = match.end()
+                continue
+        if char.isalnum():
+            j = i + 1
+            while j < n and (title[j].isalnum() or title[j] in _TOKEN_INNER):
+                j += 1
+            token_end = j
+            while token_end > i and title[token_end - 1] in _TOKEN_TRAIL_STRIP:
+                token_end -= 1
+            token = title[i:token_end]
+            if _is_protectable_token(token):
+                out.append("{" + token + "}")
+            else:
+                out.append(token)
+            out.append(title[token_end:j])
+            i = j
+            continue
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
+def apply_keep_fields(entry_dict, keep_names):
+    """Return a new entry dict restricted to an allowlist of fields.
+
+    ``ID`` and ``ENTRYTYPE`` are always kept. An empty ``keep_names`` is a
+    no-op (all fields are copied) so the CLI default matches current
+    behavior. Field-name matching is case-insensitive.
+    """
+    if not entry_dict:
+        return {} if entry_dict is None else dict(entry_dict)
+    entry = dict(entry_dict)
+    names = _as_keep_names(keep_names)
+    if not names:
+        return entry
+    allow = {name.lower() for name in names}
+    always = ("ID", "ENTRYTYPE")
+    kept = {}
+    for key, value in entry.items():
+        if key in always or str(key).lower() in allow:
+            kept[key] = value
+    return kept

--- a/rebiber/normalize.py
+++ b/rebiber/normalize.py
@@ -1,4 +1,5 @@
 from rebiber.bib2json import normalize_title, load_bib_file
+from rebiber.camera import apply_keep_fields, protect_title_caps
 import argparse
 import json
 import bibtexparser
@@ -101,7 +102,14 @@ def is_contain_var(line):
     return False
 
 
-def post_processing(output_bib_entries, removed_value_names, abbr_dict, sort):
+def post_processing(
+    output_bib_entries,
+    removed_value_names,
+    abbr_dict,
+    sort,
+    keep_names=None,
+    protect_titles=False,
+):
     bibparser = bibtexparser.bparser.BibTexParser(ignore_nonstandard_types=False)
     bib_entry_str = ""
     for entry in output_bib_entries:
@@ -134,6 +142,13 @@ def post_processing(output_bib_entries, removed_value_names, abbr_dict, sort):
                 if place in output_entry:
                     if re.match(pattern, output_entry[place], flags=re.DOTALL):
                         output_entry[place] = short
+        if keep_names:
+            kept = apply_keep_fields(output_entry, keep_names)
+            for key in list(output_entry.keys()):
+                if key not in kept:
+                    del output_entry[key]
+        if protect_titles and output_entry.get("title"):
+            output_entry["title"] = protect_title_caps(output_entry["title"])
 
     writer = BibTexWriter()
     if not sort:
@@ -652,6 +667,8 @@ def normalize_bib(
     used_keys=None,
     live_lookup=False,
     dblp_search=None,
+    keep_names=None,
+    protect_titles=False,
 ):
     removed_value_names = list(removed_value_names or [])
     abbr_dict = list(abbr_dict or [])
@@ -828,7 +845,12 @@ def normalize_bib(
     print_summary(stats)
     print(stats["report"], end="")
     output_string = post_processing(
-        output_bib_entries, removed_value_names, abbr_dict, sort
+        output_bib_entries,
+        removed_value_names,
+        abbr_dict,
+        sort,
+        keep_names=keep_names,
+        protect_titles=protect_titles,
     )
     stats["output"] = output_string
 
@@ -1008,6 +1030,20 @@ def build_parser(filepath=None):
         help="On local-index miss, search DBLP by title (opt-in; uses network). "
         "Respect DBLP rate limits; default is local-only / offline.",
     )
+    parser.add_argument(
+        "--keep",
+        default="",
+        type=str,
+        help="A comma-separated allowlist of fields to keep (ID and ENTRYTYPE "
+        "are always kept). Empty (default) keeps current behavior. Example: "
+        "'--keep author,title,booktitle,journal,year,volume,number,pages,doi'.",
+    )
+    parser.add_argument(
+        "--protect-titles",
+        action="store_true",
+        help="Wrap uppercase tokens/acronyms in titles with braces so BibTeX "
+        "styles do not lowercase them.",
+    )
     return parser
 
 
@@ -1047,6 +1083,7 @@ def main(argv=None):
         bib_db = construct_bib_db(args.bib_list, start_dir=filepath)
 
     removed_value_names = [s.strip() for s in args.remove.split(",") if s.strip()]
+    keep_names = [s.strip() for s in args.keep.split(",") if s.strip()]
     if args.shorten:
         abbr_dict = load_abbr_tsv(args.abbr_tsv)
     else:
@@ -1074,6 +1111,8 @@ def main(argv=None):
             dry_run=args.dry_run,
             used_keys=used_keys,
             live_lookup=args.live_lookup,
+            keep_names=keep_names,
+            protect_titles=args.protect_titles,
         )
         reports.append(stats.get("report") or "")
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,0 +1,88 @@
+"""Unit tests for camera-ready helpers (pure; no I/O)."""
+
+from rebiber.camera import apply_keep_fields, protect_title_caps
+
+
+def test_protect_acronyms_not_title_case_words():
+    assert protect_title_caps("Deep Learning") == "Deep Learning"
+    assert protect_title_caps("BERT") == "{BERT}"
+    assert protect_title_caps("BERT: Pre-training of NLP") == (
+        "{BERT}: Pre-training of {NLP}"
+    )
+    assert protect_title_caps("A BERT Model") == "A {BERT} Model"
+
+
+def test_protect_does_not_double_brace_whole_title():
+    # The usual anti-pattern is {{Whole Title Here}}.
+    result = protect_title_caps("BERT for NLP")
+    assert result == "{BERT} for {NLP}"
+    assert result != "{BERT for NLP}"
+    assert result != "{{BERT} for {NLP}}"
+
+    already_whole = "{Deep Learning with BERT}"
+    assert protect_title_caps(already_whole) == already_whole
+
+    already_token = "{BERT}: Pre-training"
+    assert protect_title_caps(already_token) == already_token
+    assert protect_title_caps("{BERT}") == "{BERT}"
+
+
+def test_protect_mixed_case_and_digits():
+    assert protect_title_caps("ResNet and PyTorch") == "{ResNet} and {PyTorch}"
+    assert protect_title_caps("GPT-2 and 3D vision") == "{GPT-2} and {3D} vision"
+    assert protect_title_caps("C++ parsers") == "{C++} parsers"
+
+
+def test_protect_empty_and_none():
+    assert protect_title_caps("") == ""
+    assert protect_title_caps(None) == ""
+
+
+def test_apply_keep_always_keeps_id_and_entrytype():
+    entry = {
+        "ID": "x",
+        "ENTRYTYPE": "article",
+        "title": "Hello",
+        "author": "Ada",
+        "note": "drop me",
+        "url": "http://x",
+    }
+    kept = apply_keep_fields(entry, ["title", "author"])
+    assert kept == {
+        "ID": "x",
+        "ENTRYTYPE": "article",
+        "title": "Hello",
+        "author": "Ada",
+    }
+    # Pure: original is unchanged.
+    assert "note" in entry
+    assert "url" in entry
+
+
+def test_apply_keep_empty_is_noop():
+    entry = {"ID": "x", "ENTRYTYPE": "article", "note": "keep"}
+    assert apply_keep_fields(entry, []) == entry
+    assert apply_keep_fields(entry, None) == entry
+    assert apply_keep_fields(entry, "") == entry
+
+
+def test_apply_keep_case_insensitive_and_comma_string():
+    entry = {
+        "ID": "x",
+        "ENTRYTYPE": "article",
+        "title": "T",
+        "doi": "10.1",
+        "note": "no",
+    }
+    kept = apply_keep_fields(entry, ["Title", "DOI"])
+    assert set(kept) == {"ID", "ENTRYTYPE", "title", "doi"}
+    kept_str = apply_keep_fields(entry, "author,title,booktitle,journal,year,volume,number,pages,doi")
+    assert "title" in kept_str
+    assert "doi" in kept_str
+    assert "note" not in kept_str
+    assert kept_str["ID"] == "x"
+
+
+def test_apply_keep_none_entry():
+    assert apply_keep_fields(None, ["title"]) == {}
+    assert apply_keep_fields({}, ["title"]) == {}

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1079,5 +1079,73 @@ class TestLiveDblpLookup(unittest.TestCase):
         self.assertTrue(args.live_lookup)
 
 
+CAMERA_READY_INPUT = """@article{deeplearning,
+  title = {Deep Learning with BERT and NLP},
+  author = {LeCun, Yann},
+  year = {2015},
+  journal = {Nature},
+  volume = {521},
+  pages = {436--444},
+  url = {https://example.com},
+  note = {drop me},
+  doi = {10.1038/nature14539}
+}
+"""
+
+
+class TestCameraReadyNormalize(unittest.TestCase):
+    def test_keep_fields_allowlist(self):
+        output, _stats = run_normalize(
+            CAMERA_READY_INPUT,
+            {},
+            format_only=True,
+            keep_names=["author", "title", "journal", "year", "doi"],
+        )
+        entry = parse_first_entry(output)
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry["ID"], "deeplearning")
+        self.assertEqual(entry["ENTRYTYPE"], "article")
+        self.assertEqual(entry.get("title"), "Deep Learning with BERT and NLP")
+        self.assertIn("author", entry)
+        self.assertEqual(entry.get("journal"), "Nature")
+        self.assertEqual(entry.get("doi"), "10.1038/nature14539")
+        self.assertNotIn("url", entry)
+        self.assertNotIn("note", entry)
+        self.assertNotIn("pages", entry)
+        self.assertNotIn("volume", entry)
+
+    def test_protect_titles_wraps_acronyms(self):
+        output, _stats = run_normalize(
+            CAMERA_READY_INPUT, {}, format_only=True, protect_titles=True
+        )
+        entry = parse_first_entry(output)
+        self.assertIsNotNone(entry)
+        title = entry.get("title", "")
+        self.assertIn("{BERT}", title)
+        self.assertIn("{NLP}", title)
+        self.assertNotEqual(title, "{Deep Learning with BERT and NLP}")
+        self.assertIn("url", entry)
+
+    def test_cli_keep_and_protect_defaults(self):
+        parser = build_parser()
+        args = parser.parse_args(["-i", "a.bib"])
+        self.assertEqual(args.keep, "")
+        self.assertFalse(args.protect_titles)
+        args = parser.parse_args(
+            [
+                "-i",
+                "a.bib",
+                "--keep",
+                "author,title,booktitle,journal,year,volume,number,pages,doi",
+                "--protect-titles",
+            ]
+        )
+        self.assertEqual(
+            args.keep,
+            "author,title,booktitle,journal,year,volume,number,pages,doi",
+        )
+        self.assertTrue(args.protect_titles)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Opt-in camera-ready post-processing with a small conflict surface.

## What
- New `rebiber/camera.py` with two pure helpers:
  - `protect_title_caps(title)` wraps uppercase tokens / acronyms in braces and does **not** brace the whole title.
  - `apply_keep_fields(entry, keep_names)` allowlists fields; `ID` and `ENTRYTYPE` are always kept. Empty keep list is a no-op.
- Wired only in `post_processing` / `normalize_bib` (after matching, arXiv rewrite, and abbreviations).
- CLI:
  - `--keep author,title,booktitle,journal,year,volume,number,pages,doi` (default empty = current behavior)
  - `--protect-titles` (`store_true`, default off)

## What this does not change
Author matching, live DBLP lookup, and `bib2json` are untouched.

## Tests
- `tests/test_camera.py` for the pure helpers
- A few `normalize_bib` / argparse tests in `tests/test_normalize.py`
- `uv run --python 3.9 pytest tests` is green locally (107 passed)