### PR TITLE
Add CLI integration tests and honest help/examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,18 +100,19 @@ rebiber -i input.bib [more.bib ...] [-o out.bib|outdir]
 Examples:
 
 ```bash
+# report what would change without writing (start here)
+rebiber -i input.bib --dry-run
+# leftover unofficial arXiv entries may still query the arXiv API unless --format-only
+
+# pretty-print only: no DB matching, no DBLP, no arXiv API
+rebiber -i input.bib -o pretty.bib --format-only
+
 # single file (writes back to input.bib if -o is omitted)
 rebiber -i examples/input.bib -o examples/output.bib
 
 # batch: multiple files or a glob; -o can be a directory
 rebiber -i *.bib
 rebiber -i paper1.bib paper2.bib -o ./normalized/
-
-# pretty-print only (no official-info replacement; useful for diffs)
-rebiber -i input.bib -o pretty.bib --format-only
-
-# report what would change without writing
-rebiber -i input.bib --dry-run
 
 # also write the change report to a file (always printed to stdout)
 rebiber -i input.bib --dry-run --report changes.txt
@@ -131,8 +132,8 @@ rebiber -i input.bib [more.bib ...] [-o out.bib|outdir]
   -s/--shorten True|False   (default False)
   -d/--deduplicate True|False (default True)
   -st/--sort True|False (default False)
-  --format-only   # pretty-print only, for diffs (issue 66)
-  --dry-run       # report without writing
+  --format-only   # pretty-print only; no DB / DBLP / arXiv API (issue 66)
+  --dry-run       # report without writing (leftover arXiv may still hit the arXiv API)
   --report PATH   # also write the change report to PATH
   --used-in FILE [FILE ...]  # only convert keys cited in these .tex files
   --live-lookup   # opt-in DBLP title search on local misses (uses network)
@@ -151,8 +152,8 @@ rebiber -i input.bib [more.bib ...] [-o out.bib|outdir]
 | `-s` | or `--shorten`. `True`/`False`, **False** by default. Replace `booktitle`/`journal` with abbreviations from `-a`. Used as `-s True`. |
 | `-d` | or `--deduplicate`. `True`/`False`, **True** by default. Remove duplicate bib entries that share the same key. Used as `-d True`. |
 | `-st` | or `--sort`. `True`/`False`, **False** by default. Keep the input order unless set to `True` (then entries are ordered alphabetically). Used as `-st True`. |
-| `--format-only` | Pretty-print / normalize formatting only. Do not replace entries with official DBLP/ACL records. Handy for reviewing diffs. |
-| `--dry-run` | Report conversions and issues without writing output files. |
+| `--format-only` | Pretty-print / normalize formatting only. Do not replace entries with official DBLP/ACL records and do not query DBLP or the arXiv API. Handy for reviewing diffs or a network-free run. |
+| `--dry-run` | Report conversions and issues without writing output files. Leftover unofficial arXiv entries may still query the arXiv API unless `--format-only`. |
 | `--report` | Optional path. Also write the human-readable change report (cite key, before/after venue, reason) to this file. The report is always printed to stdout. |
 | `--used-in` | One or more `.tex` files. Only convert or arXiv-normalize bib entries whose cite keys appear in `\\cite` / `\\citep` / `\\citet` / `\\citealp` / `\\citeyear` / `\\nocite` (starred and optional-arg forms included). Unused keys are left unchanged. |
 | `--live-lookup` | Opt-in. After a local-index miss, query DBLP's publication search by title and replace the entry if the title key and authors overlap. Timeout / HTTP errors / no hit keep the original entry. **Off by default** (no network). Please respect [DBLP's rate limits](https://dblp.org/faq/How+to+use+the+dblp+search+API.html); do not run this on huge bib files in a tight loop. |

--- a/rebiber/normalize.py
+++ b/rebiber/normalize.py
@@ -910,7 +910,27 @@ def build_parser(filepath=None):
     if filepath is None:
         filepath = os.path.dirname(os.path.abspath(__file__)) + "/"
     parser = argparse.ArgumentParser(
-        description="Normalize BibTeX entries using official conference data."
+        description=(
+            "Normalize BibTeX entries using official conference data. "
+            "Default is local-index only (no DBLP). Leftover unofficial arXiv "
+            "entries may still query the arXiv API unless --format-only."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  rebiber -i input.bib --dry-run\n"
+            "      Report conversions without writing output files.\n"
+            "  rebiber -i input.bib --used-in paper.tex appendix.tex\n"
+            "      Only convert keys cited in these .tex files; unused keys stay.\n"
+            "  rebiber -i input.bib --live-lookup\n"
+            "      After a local miss, search DBLP by title (uses network).\n"
+            "  rebiber -i input.bib -o pretty.bib --format-only\n"
+            "      Pretty-print only: no DB matching, no DBLP, no arXiv API.\n"
+            "\n"
+            "Note: leftover unofficial arXiv entries may still query the arXiv API\n"
+            "unless you pass --format-only. --dry-run skips writing files but does\n"
+            "not skip that lookup."
+        ),
     )
     parser.add_argument(
         "-u", "--update", action="store_true", help="Update the data of bib and abbr."
@@ -980,12 +1000,15 @@ def build_parser(filepath=None):
     parser.add_argument(
         "--format-only",
         action="store_true",
-        help="Only pretty-print / apply abbreviations; skip DB matching and arXiv rewrite.",
+        help="Pretty-print / apply abbreviations only. Skip DB matching, live "
+        "DBLP, and the arXiv API. Use this for a network-free run.",
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Print the conversion report but do not write output files.",
+        help="Print the conversion report but do not write output files. "
+        "Leftover unofficial arXiv entries may still query the arXiv API "
+        "unless --format-only.",
     )
     parser.add_argument(
         "--report",
@@ -1000,13 +1023,14 @@ def build_parser(filepath=None):
         metavar="FILE",
         default=None,
         help="Only convert or arXiv-normalize entries whose cite keys appear "
-        "in these .tex files. Unused bib keys are left unchanged.",
+        "in these .tex files. Unused bib keys are left unchanged "
+        "(venue and arXiv fields stay as-is).",
     )
     parser.add_argument(
         "--live-lookup",
         action="store_true",
         help="On local-index miss, search DBLP by title (opt-in; uses network). "
-        "Respect DBLP rate limits; default is local-only / offline.",
+        "Off by default: no DBLP. Respect DBLP rate limits.",
     )
     return parser
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,269 @@
+"""CLI integration tests: default is offline; flags follow the advertised paths."""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import bibtexparser
+
+from rebiber.bib2json import normalize_title
+from rebiber.normalize import build_parser, main
+
+
+USED_TITLE = "A Completely Unique CLI Used Title Not In Packaged Dumps"
+UNUSED_TITLE = "A Completely Unique CLI Unused Title Not In Packaged Dumps"
+MISS_TITLE = "A Completely Unique CLI Local Miss Title Not In Packaged Dumps"
+
+USED_KEY = "keepme"
+UNUSED_KEY = "skipme"
+MISS_KEY = "workshopmiss"
+
+
+def _entry_lines(bibtex_str):
+    return [line + "\n" for line in bibtex_str.strip().split("\n")]
+
+
+def official_entry(title, author, booktitle):
+    return """@inproceedings{official,
+  title={%s},
+  author={%s},
+  booktitle={%s},
+  year={2020}
+}
+""" % (
+        title,
+        author,
+        booktitle,
+    )
+
+
+def article_entry(key, title, author, journal):
+    return """@article{%s,
+  title={%s},
+  author={%s},
+  journal={%s},
+  year={2020}
+}
+""" % (
+        key,
+        title,
+        author,
+        journal,
+    )
+
+
+def write_tiny_bib_list(directory, title_to_official):
+    """Write a one-file index that ``main`` can load via ``-l`` (absolute paths)."""
+    db = {}
+    for title, bibtex_str in title_to_official.items():
+        db[normalize_title(title, keep_digits=True)] = _entry_lines(bibtex_str)
+    json_path = os.path.join(directory, "tiny.json")
+    with open(json_path, "w", encoding="utf8") as handle:
+        json.dump(db, handle)
+    list_path = os.path.join(directory, "bib_list.txt")
+    with open(list_path, "w", encoding="utf8") as handle:
+        handle.write(json_path + "\n")
+    return list_path
+
+
+def write_text(directory, name, text):
+    path = os.path.join(directory, name)
+    with open(path, "w", encoding="utf8") as handle:
+        handle.write(text)
+    return path
+
+
+def read_text(path):
+    with open(path, encoding="utf8") as handle:
+        return handle.read()
+
+
+def parse_by_id(bib_text):
+    parsed = bibtexparser.loads(bib_text)
+    return {entry["ID"]: entry for entry in parsed.entries}
+
+
+def raise_if_dblp_called(*_args, **_kwargs):
+    raise AssertionError("search_dblp_by_title must not be called by default")
+
+
+class TestCliMain(unittest.TestCase):
+    def test_default_main_does_not_call_dblp(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            in_path = write_text(
+                tmp,
+                "in.bib",
+                article_entry(
+                    MISS_KEY,
+                    MISS_TITLE,
+                    "Ada Lovelace",
+                    "Some Workshop Notes",
+                ),
+            )
+            out_path = os.path.join(tmp, "out.bib")
+            list_path = write_tiny_bib_list(tmp, {})
+            with patch(
+                "rebiber.normalize.search_dblp_by_title",
+                side_effect=raise_if_dblp_called,
+            ):
+                main(["-i", in_path, "-o", out_path, "-l", list_path])
+            self.assertTrue(os.path.isfile(out_path))
+            entry = parse_by_id(read_text(out_path))[MISS_KEY]
+            self.assertEqual(entry.get("journal"), "Some Workshop Notes")
+            self.assertNotIn("booktitle", entry)
+
+    def test_live_lookup_reaches_search_empty_keeps_original(self):
+        calls = []
+
+        def mock_search(title, timeout=10, opener=None):
+            calls.append(title)
+            return []
+
+        with tempfile.TemporaryDirectory() as tmp:
+            in_path = write_text(
+                tmp,
+                "in.bib",
+                article_entry(
+                    MISS_KEY,
+                    MISS_TITLE,
+                    "Ada Lovelace",
+                    "Some Workshop Notes",
+                ),
+            )
+            out_path = os.path.join(tmp, "out.bib")
+            list_path = write_tiny_bib_list(tmp, {})
+            with patch(
+                "rebiber.normalize.search_dblp_by_title",
+                side_effect=mock_search,
+            ):
+                main(
+                    [
+                        "-i",
+                        in_path,
+                        "-o",
+                        out_path,
+                        "-l",
+                        list_path,
+                        "--live-lookup",
+                    ]
+                )
+            self.assertEqual(len(calls), 1)
+            self.assertIn("Unique CLI Local Miss", calls[0])
+            entry = parse_by_id(read_text(out_path))[MISS_KEY]
+            self.assertEqual(entry.get("journal"), "Some Workshop Notes")
+            self.assertNotIn("booktitle", entry)
+
+    def test_dry_run_does_not_create_output_and_reports_converted_key(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            in_path = write_text(
+                tmp,
+                "in.bib",
+                article_entry(
+                    USED_KEY,
+                    USED_TITLE,
+                    "Ada Lovelace",
+                    "Some Workshop Notes",
+                ),
+            )
+            out_path = os.path.join(tmp, "out.bib")
+            report_path = os.path.join(tmp, "report.txt")
+            list_path = write_tiny_bib_list(
+                tmp,
+                {
+                    USED_TITLE: official_entry(
+                        USED_TITLE, "Ada Lovelace", "Proc. of ICML"
+                    )
+                },
+            )
+            with patch(
+                "rebiber.normalize.search_dblp_by_title",
+                side_effect=raise_if_dblp_called,
+            ):
+                main(
+                    [
+                        "-i",
+                        in_path,
+                        "-o",
+                        out_path,
+                        "-l",
+                        list_path,
+                        "--dry-run",
+                        "--report",
+                        report_path,
+                    ]
+                )
+            self.assertFalse(os.path.isfile(out_path))
+            report = read_text(report_path)
+            self.assertIn(USED_KEY, report)
+            self.assertIn("converted", report)
+            self.assertIn("Proc. of ICML", report)
+
+    def test_used_in_unused_key_not_converted(self):
+        two_papers = article_entry(
+            USED_KEY,
+            USED_TITLE,
+            "Ada Lovelace",
+            "Some Workshop Notes",
+        ) + article_entry(
+            UNUSED_KEY,
+            UNUSED_TITLE,
+            "Alan Turing",
+            "Some Workshop Notes",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            in_path = write_text(tmp, "in.bib", two_papers)
+            out_path = os.path.join(tmp, "out.bib")
+            tex_path = write_text(tmp, "paper.tex", r"See \cite{keepme}." + "\n")
+            list_path = write_tiny_bib_list(
+                tmp,
+                {
+                    USED_TITLE: official_entry(
+                        USED_TITLE, "Ada Lovelace", "Proc. of ICML"
+                    ),
+                    UNUSED_TITLE: official_entry(
+                        UNUSED_TITLE, "Alan Turing", "Proc. of NeurIPS"
+                    ),
+                },
+            )
+            with patch(
+                "rebiber.normalize.search_dblp_by_title",
+                side_effect=raise_if_dblp_called,
+            ):
+                main(
+                    [
+                        "-i",
+                        in_path,
+                        "-o",
+                        out_path,
+                        "-l",
+                        list_path,
+                        "--used-in",
+                        tex_path,
+                    ]
+                )
+            by_id = parse_by_id(read_text(out_path))
+            self.assertEqual(by_id[USED_KEY].get("booktitle"), "Proc. of ICML")
+            self.assertEqual(
+                by_id[UNUSED_KEY].get("journal"), "Some Workshop Notes"
+            )
+            self.assertNotIn("booktitle", by_id[UNUSED_KEY])
+
+
+class TestCliHelp(unittest.TestCase):
+    def test_help_epilog_has_examples_and_arxiv_api_note(self):
+        help_text = build_parser().format_help()
+        self.assertIn("--dry-run", help_text)
+        self.assertIn("--used-in", help_text)
+        self.assertIn("--live-lookup", help_text)
+        self.assertIn("--format-only", help_text)
+        self.assertIn("rebiber -i input.bib --dry-run", help_text)
+        self.assertIn("rebiber -i input.bib --used-in paper.tex", help_text)
+        self.assertIn("rebiber -i input.bib --live-lookup", help_text)
+        self.assertIn("rebiber -i input.bib -o pretty.bib --format-only", help_text)
+        self.assertIn("arXiv API", help_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
CLI integration tests through `main()` plus help/README that match the actual network behavior.

## Tests (`tests/test_cli.py`)
- `main(["-i", in.bib, "-o", out.bib])` with `search_dblp_by_title` patched to raise if called — default is no DBLP.
- `--live-lookup` reaches search (mock returns `[]`, original kept).
- `--dry-run` does not create the output file; report contains the converted key on a DB hit.
- `--used-in` leaves an unused key unconverted (venue stays).

Tiny temp bibs + a one-file index via `-l` (absolute path) so `construct_bib_db` does not load the packaged dumps. Matching logic is unchanged.

## Help / docs
- `--help` epilog with dry-run / used-in / live-lookup / format-only examples.
- Clarify leftover unofficial arXiv entries may still hit the arXiv API unless `--format-only`.
- README usage examples start with `--dry-run`.

`uv run pytest tests` is green locally (101 passed).